### PR TITLE
Unitonunwalkabletile fix

### DIFF
--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -2106,11 +2106,19 @@ begin
     if DesiredPassability = tpWalkRoad then
     begin
       if not gTerrain.CheckPassability(fNextPosition, tpWalk) then
-        raise ELocError.Create( gRes.Units[UnitType].GUIName+' on unwalkable tile at '+KM_Points.TypeToString(fNextPosition)+' pass CanWalk', fNextPosition);
+        Self.KillUnit(PLAYER_NONE, False, True);
+        //Grayter 18.01.2018
+        //Despite checking passability of current tile, some units can walk on
+        //unwalkable tile especially when there are many soldiers on the map (> 4000)
+        //I don't know why it happens really, so we decided to kill this unit instead
+        //of rising error. This problem does not occur in 99.9% gameplays and is fired
+        //randomly so it is practically impossible to debug.
+        //raise ELocError.Create( gRes.Units[UnitType].GUIName+' on unwalkable tile at '+KM_Points.TypeToString(fNextPosition)+' pass CanWalk', fNextPosition);
     end else
     if not gTerrain.CheckPassability(fNextPosition, DesiredPassability) then
-      raise ELocError.Create(gRes.Units[UnitType].GUIName+' on unwalkable tile at '+KM_Points.TypeToString(fNextPosition)+' "'+PassabilityGuiText[DesiredPassability] + '"', fNextPosition);
-
+      Self.KillUnit(PLAYER_NONE, False, True);
+      //Explanation above
+      //raise ELocError.Create(gRes.Units[UnitType].GUIName+' on unwalkable tile at '+KM_Points.TypeToString(fNextPosition)+' "'+PassabilityGuiText[DesiredPassability] + '"', fNextPosition);
 
   //
   //Performing Tasks and Actions now


### PR DESCRIPTION

Killing problematic unit instead of rising error and crashing the game. 