### PR TITLE
Fix the position of the buttons Undo and Rendo

### DIFF
--- a/src/gui/pages_maped/terrain/KM_GUIMapEdTerrain.pas
+++ b/src/gui/pages_maped/terrain/KM_GUIMapEdTerrain.pas
@@ -85,10 +85,10 @@ begin
       Button_Terrain[I].OnClick := PageChange;
     end;
 
-    Button_TerrainUndo := TKMButton.Create(Panel_Terrain, 155, 0, 15, 26, '<', bsGame);
+    Button_TerrainUndo := TKMButton.Create(Panel_Terrain, 151, 0, 15, SMALL_TAB_H, '<', bsGame);
     Button_TerrainUndo.Hint := gResTexts[TX_MAPED_UNDO_HINT]+ ' (''Ctrl+Z'')';
     Button_TerrainUndo.OnClick := UnRedoClick;
-    Button_TerrainRedo := TKMButton.Create(Panel_Terrain, 170, 0, 15, 26, '>', bsGame);
+    Button_TerrainRedo := TKMButton.Create(Panel_Terrain, 166, 0, 15, SMALL_TAB_H, '>', bsGame);
     Button_TerrainRedo.Hint := gResTexts[TX_MAPED_REDO_HINT] + ' (''Ctrl+Y'' or ''Ctrl+Shift+Z'')';
     Button_TerrainRedo.OnClick := UnRedoClick;
 


### PR DESCRIPTION
It was before correction:
![KMR_Баг_1_Было](https://user-images.githubusercontent.com/17384156/56499074-325eab00-651e-11e9-9b76-4322de1c264c.jpg)
It became after the correction:
![KMR_Баг_1_Стало (Исправлен)](https://user-images.githubusercontent.com/17384156/56499077-35f23200-651e-11e9-8de0-f271501d131a.jpg)