### PR TITLE
MultiSelect in RXXEditor with working Target Directory export

### DIFF
--- a/Utils/RXXEditor/RXXEditorForm.dfm
+++ b/Utils/RXXEditor/RXXEditorForm.dfm
@@ -244,4 +244,13 @@ object RXXForm1: TRXXForm1
     Left = 32
     Top = 128
   end
+  object SelectDirectoryDialog1: TFileOpenDialog
+    FavoriteLinks = <>
+    FileTypes = <>
+    OkButtonLabel = 'Select'
+    Options = [fdoPickFolders, fdoForceFileSystem, fdoPathMustExist]
+    Title = 'Select Directory'
+    Left = 136
+    Top = 72
+  end
 end


### PR DESCRIPTION
With this now you can select multiple images at once and export them into a selected directory. The exported files will be named as `<ID>.png` and `<ID>a.png`.