### PR TITLE
Fixed serfs side stepping around unit that is no longer there

### DIFF
--- a/src/ai/newAI/KM_ArmyAttack.pas
+++ b/src/ai/newAI/KM_ArmyAttack.pas
@@ -315,21 +315,25 @@ procedure TAISquad.UpdateState(aTick: Cardinal);
     begin
       BestTgt := nil;
       G := TKMUnitWarrior(fTargetUnit).Group;
-      BestDist := 1E10;
-      for K := 0 to G.Count - 1 do
-        if not G.Members[K].IsDeadOrDying then
-        begin
-          Dist := KMDistanceSqr(fGroup.Position,G.Members[K].CurrPosition);
-          if (Dist < BestDist) then
-          begin
-            BestTgt := G.Members[K];
-            BestDist := Dist;
-          end;
-        end;
-      if (BestTgt <> nil) then
+      //Group will be nil if we target a warrior still walking out of barracks
+      if G <> nil then
       begin
-        gHands.CleanUpUnitPointer(fTargetUnit);
-        fTargetUnit := BestTgt.GetUnitPointer;
+        BestDist := 1E10;
+        for K := 0 to G.Count - 1 do
+          if not G.Members[K].IsDeadOrDying then
+          begin
+            Dist := KMDistanceSqr(fGroup.Position,G.Members[K].CurrPosition);
+            if (Dist < BestDist) then
+            begin
+              BestTgt := G.Members[K];
+              BestDist := Dist;
+            end;
+          end;
+        if (BestTgt <> nil) then
+        begin
+          gHands.CleanUpUnitPointer(fTargetUnit);
+          fTargetUnit := BestTgt.GetUnitPointer;
+        end;
       end;
     end;
   end;

--- a/src/ai/newAI/KM_ArmyAttackNew.pas
+++ b/src/ai/newAI/KM_ArmyAttackNew.pas
@@ -305,21 +305,25 @@ procedure TKMCombatGroup.UpdateState(aTick: Cardinal);
     begin
       BestTgt := nil;
       G := TKMUnitWarrior(fTargetUnit).Group;
-      BestDist := 1E10;
-      for K := 0 to G.Count - 1 do
-        if not G.Members[K].IsDeadOrDying then
-        begin
-          Dist := KMDistanceSqr(fGroup.Position,G.Members[K].CurrPosition);
-          if (Dist < BestDist) then
-          begin
-            BestTgt := G.Members[K];
-            BestDist := Dist;
-          end;
-        end;
-      if (BestTgt <> nil) then
+      //Group will be nil if we target a warrior still walking out of barracks
+      if G <> nil then
       begin
-        gHands.CleanUpUnitPointer(fTargetUnit);
-        fTargetUnit := BestTgt.GetUnitPointer;
+        BestDist := 1E10;
+        for K := 0 to G.Count - 1 do
+          if not G.Members[K].IsDeadOrDying then
+          begin
+            Dist := KMDistanceSqr(fGroup.Position,G.Members[K].CurrPosition);
+            if (Dist < BestDist) then
+            begin
+              BestTgt := G.Members[K];
+              BestDist := Dist;
+            end;
+          end;
+        if (BestTgt <> nil) then
+        begin
+          gHands.CleanUpUnitPointer(fTargetUnit);
+          fTargetUnit := BestTgt.GetUnitPointer;
+        end;
       end;
     end;
   end;

--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -590,7 +590,7 @@ const
             terKind := CornersTerKinds[(D div 2) mod 4]
           else
           begin
-            adj := KaMRandom(2, 'TKMTerrain.SaveToFile.SetNewLand'); //Choose randomly between 2 corners terkinds
+            adj := Random(2); //Choose randomly between 2 corners terkinds
             terKind  := CornersTerKinds[((D div 2) + adj) mod 4];
           end;
         end;
@@ -598,12 +598,12 @@ const
 
       //Apply some random tiles for artisticity
       TileBasic.BaseLayer.Terrain  := gGame.TerrainPainter.PickRandomTile(terKind, True);
-      TileBasic.BaseLayer.Rotation := KaMRandom(4, 'TKMTerrain.SaveToFile.SetNewLand 2');
+      TileBasic.BaseLayer.Rotation := Random(4);
       TileBasic.BaseLayer.SetCorners([0,1,2,3]);
       //find height mid point to make random elevation even for close to 0 or 100 height
       hMid := Max(0, Land[aFromY,aFromX].Height - H_RND_HALF) + H_RND_HALF;
       hMid := Min(100, hMid + H_RND_HALF) - H_RND_HALF;
-      TileBasic.Height    := EnsureRange(hMid - H_RND_HALF + KaMRandom(HEIGHT_RAND_VALUE, 'TKMTerrain.SaveToFile.SetNewLand 3'), 0, 100);
+      TileBasic.Height    := EnsureRange(hMid - H_RND_HALF + Random(HEIGHT_RAND_VALUE), 0, 100);
       TileBasic.Obj       := OBJ_NONE; // No object
       TileBasic.IsCustom  := False;
       TileBasic.BlendingLvl := DEFAULT_BLENDING_LVL;

--- a/src/units/actions/KM_UnitActionWalkTo.pas
+++ b/src/units/actions/KM_UnitActionWalkTo.pas
@@ -1219,7 +1219,8 @@ begin
     end;
 
     //Attempt to smooth out unnecessary side-steps in the route
-    SmoothDiagSideStep;
+    if not fDoExchange then
+      SmoothDiagSideStep;
 
     //If we were in Worker mode but have now reached the walk network of our destination switch to CanWalk mode to avoid walking on other building sites
     {if (fPass = CanWorker) and (fTerrain.GetWalkConnectID(fWalkTo) <> 0) and

--- a/src/units/actions/KM_UnitActionWalkTo.pas
+++ b/src/units/actions/KM_UnitActionWalkTo.pas
@@ -59,6 +59,7 @@ type
 
     procedure ChangeStepTo(const aPos: TKMPoint);
     procedure PerformExchange(const ForcedExchangePos: TKMPoint);
+    procedure SmoothDiagSideStep;
     procedure IncVertex;
     procedure DecVertex;
     procedure SetInitValues;
@@ -399,6 +400,45 @@ begin
     NodeList.Insert(NodePos+1, aPos);
 
   fUnit.Direction := KMGetDirection(fUnit.CurrPosition, aPos); //Face the new tile
+end;
+
+
+procedure TKMUnitActionWalkTo.SmoothDiagSideStep;
+var
+  A, B, C, Candidate: TKMPoint;
+begin
+  //Attempt to smooth out unnecessary side-steps in the route
+  //Pathfinding will sometimes make a straight line route dodge diagonally
+  //around a unit that was occupying the tile. If that unit is no longer there
+  //we can smooth out the diagonal side step: (x is the tile unnecessarily dodged)
+  // .
+  //.x
+  // .
+
+  if (NodePos+2 <= NodeList.Count-1) then
+  begin
+    A := NodeList[NodePos];
+    B := NodeList[NodePos+1];
+    C := NodeList[NodePos+2];
+
+    if (A.X = C.X) and (Abs(A.Y - C.Y) = 2) //We are headed in straight line
+    and (A.X <> B.X) then //Next step is diagonal
+      Candidate := KMPoint(A.X, B.Y)
+    else
+      if (A.Y = C.Y) and (Abs(A.X - C.X) = 2) //We are headed in straight line
+      and (A.Y <> B.Y) then //Next step is diagonal
+        Candidate := KMPoint(B.X, A.Y)
+      else
+        Exit;
+
+    //Check if candidate is walkable and doesn't have a unit
+    if (fPass in gTerrain.Land[Candidate.Y, Candidate.X].Passability)
+    and not gTerrain.HasUnit(Candidate) then
+    begin
+      //Candidate is better, so update route
+      NodeList[NodePos+1] := Candidate;
+    end;
+  end;
 end;
 
 
@@ -1177,6 +1217,9 @@ begin
       Inc(NodePos); //Inc the node pos and exit so this step is simply skipped
       Exit; //Will take next step during next execute
     end;
+
+    //Attempt to smooth out unnecessary side-steps in the route
+    SmoothDiagSideStep;
 
     //If we were in Worker mode but have now reached the walk network of our destination switch to CanWalk mode to avoid walking on other building sites
     {if (fPass = CanWorker) and (fTerrain.GetWalkConnectID(fWalkTo) <> 0) and


### PR DESCRIPTION
Someone mentioned this on discord, where a serf dodges around an empty space because there was a unit in it when the route was calculated