### PR TITLE
Script sound fixes

### DIFF
--- a/src/game/KM_Game.pas
+++ b/src/game/KM_Game.pas
@@ -1356,7 +1356,7 @@ end;
 
 function TKMGame.GetMissionFile: UnicodeString;
 begin
-  if not IsMultiPlayerOrSpec then
+  if not IsMultiplayer then
     Result := fMissionFileSP //In SP we store it
   else
     //In MP we can't store it since it will be MapsMP or MapsDL on different clients


### PR DESCRIPTION
Fixes 3 issues:

1. Crash caused by using Move on a record containing an AnsiString (now using TObjectList instead of manual array length management)
2. Looped, FadeMusic, and AudioFormat fields were not being saved
3. In multiplayer replays sounds wouldn't play because it was getting the wrong file path