### PR TITLE
UV pixel centers

### DIFF
--- a/src/res/KM_ResFonts.pas
+++ b/src/res/KM_ResFonts.pas
@@ -150,6 +150,7 @@ var
   I, K, M, L: Integer;
   MaxHeight: Integer;
   pX, pY: Integer;
+  HalfPixelOffsetU, HalfPixelOffsetV: Single;
 begin
   MaxHeight := 0;
   if not FileExists(aFileName) then
@@ -208,6 +209,9 @@ begin
   SetLength(fAtlases, fAtlasCount);
   SetLength(fAtlases[fAtlasCount - 1].TexData, fTexSizeX * fTexSizeY);
 
+  HalfPixelOffsetU := 0.5 / fTexSizeX;
+  HalfPixelOffsetV := 0.5 / fTexSizeY;
+
   for I := 0 to fCharCount - 1 do
   if Used[I] <> 0 then
   begin
@@ -224,10 +228,10 @@ begin
       fAtlases[fAtlasCount - 1].TexData[(pY + L) * fTexSizeX + pX + M] :=
         aPalette.Color32(rawData[I, L * Letters[I].Width + M]);
 
-    Letters[I].u1 := pX / fTexSizeX;
-    Letters[I].v1 := pY / fTexSizeY;
-    Letters[I].u2 := (pX + Letters[I].Width) / fTexSizeX;
-    Letters[I].v2 := (pY + Letters[I].Height) / fTexSizeY;
+    Letters[I].u1 := HalfPixelOffsetU + pX / fTexSizeX;
+    Letters[I].v1 := HalfPixelOffsetV + pY / fTexSizeY;
+    Letters[I].u2 := -HalfPixelOffsetU + (pX + Letters[I].Width) / fTexSizeX;
+    Letters[I].v2 := -HalfPixelOffsetV + (pY + Letters[I].Height) / fTexSizeY;
 
     Inc(pX, Letters[I].Width + PAD);
   end;

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -855,16 +855,20 @@ var
   K: Integer;
   ID: Word;
   TxCoords: TKMTexCoords;
+  HalfPixelOffsetU, HalfPixelOffsetV: Single;
 begin
+  HalfPixelOffsetU := 0.5 / aSpriteInfo.Width;
+  HalfPixelOffsetV := 0.5 / aSpriteInfo.Height;
+
   for K := 0 to High(aSpriteInfo.Sprites) do
   begin
     ID := aSpriteInfo.Sprites[K].SpriteID;
 
     TxCoords.ID := aTx;
-    TxCoords.u1 := aSpriteInfo.Sprites[K].PosX / aSpriteInfo.Width;
-    TxCoords.v1 := aSpriteInfo.Sprites[K].PosY / aSpriteInfo.Height;
-    TxCoords.u2 := (aSpriteInfo.Sprites[K].PosX + aSpritesPack.RXData.Size[ID].X) / aSpriteInfo.Width;
-    TxCoords.v2 := (aSpriteInfo.Sprites[K].PosY + aSpritesPack.RXData.Size[ID].Y) / aSpriteInfo.Height;
+    TxCoords.u1 := HalfPixelOffsetU + aSpriteInfo.Sprites[K].PosX / aSpriteInfo.Width;
+    TxCoords.v1 := HalfPixelOffsetV + aSpriteInfo.Sprites[K].PosY / aSpriteInfo.Height;
+    TxCoords.u2 := -HalfPixelOffsetU + (aSpriteInfo.Sprites[K].PosX + aSpritesPack.RXData.Size[ID].X) / aSpriteInfo.Width;
+    TxCoords.v2 := -HalfPixelOffsetV + (aSpriteInfo.Sprites[K].PosY + aSpritesPack.RXData.Size[ID].Y) / aSpriteInfo.Height;
 
     if aAtlasType = saBase then
     begin


### PR DESCRIPTION
Fix for the bouncing sprites issue. OpenGL normalised texture coordinates need to centered on pixels. See:
https://i.stack.imgur.com/s3pu2.png

Possibly it only happens for certain GPUs (I'm NVIDIA) and I suspect it got worse with larger atlases. Usually because of GL_NEAREST it samples the correct value, but sometimes not.