### PR TITLE
Sprite bounce fix

### DIFF
--- a/src/KM_Minimap.pas
+++ b/src/KM_Minimap.pas
@@ -69,7 +69,7 @@ begin
   inherited Create;
 
   fSepia := aSepia;
-  fMapTex.Tex := TRender.GenerateTextureCommon;
+  fMapTex.Tex := TRender.GenerateTextureCommon(ftNearest, ftNearest);
 
   //We don't need terrain on main menu, just a parser
   //Otherwise access synced Game terrain

--- a/src/KM_Video.pas
+++ b/src/KM_Video.pas
@@ -442,7 +442,7 @@ begin
     if(FWidth > 0) and (FHeight > 0) then
     begin
       SetLength(FBuffer, FWidth * FHeight * 3);
-      FTexture.Tex := TRender.GenerateTextureCommon;
+      FTexture.Tex := TRender.GenerateTextureCommon(ftNearest, ftNearest);
 
       FMediaPlayer := libvlc_media_player_new_from_media(Media);
       libvlc_video_set_format(FMediaPlayer, 'RV24', FWidth, FHeight, FWidth * 3);

--- a/src/common/KM_Defaults.pas
+++ b/src/common/KM_Defaults.pas
@@ -155,6 +155,7 @@ var
   SHOW_ATTACK_RADIUS      :Boolean = False; //Render towers/archers attack radius
   DISPLAY_SOUNDS          :Boolean = False; //Display sounds on map
   RENDER_3D               :Boolean = False; //Experimental 3D render
+  LINEAR_FILTER_SPRITES   :Boolean = True; //To check pixel sampling alignment issues (bouncing) at 100% zoom
   HOUSE_BUILDING_STEP     :Single = 0;
   OVERLAY_NAVMESH         :Boolean = False; //Show navmesh
   OVERLAY_DEFENCES        :Boolean = False; //Show AI defence perimeters

--- a/src/common/KM_Defaults.pas
+++ b/src/common/KM_Defaults.pas
@@ -155,7 +155,7 @@ var
   SHOW_ATTACK_RADIUS      :Boolean = False; //Render towers/archers attack radius
   DISPLAY_SOUNDS          :Boolean = False; //Display sounds on map
   RENDER_3D               :Boolean = False; //Experimental 3D render
-  LINEAR_FILTER_SPRITES   :Boolean = True; //To check pixel sampling alignment issues (bouncing) at 100% zoom
+  LINEAR_FILTER_SPRITES   :Boolean = False; //To check pixel sampling alignment issues (bouncing) at 100% zoom
   HOUSE_BUILDING_STEP     :Single = 0;
   OVERLAY_NAVMESH         :Boolean = False; //Show navmesh
   OVERLAY_DEFENCES        :Boolean = False; //Show AI defence perimeters

--- a/src/render/KM_Render.pas
+++ b/src/render/KM_Render.pas
@@ -13,8 +13,13 @@ type
     tfRGBA8,
     tfAlpha8 //Mask used for team colors and house construction steps (GL_ALPHA)
     );
+  TFilterType = (
+    ftNearest,
+    ftLinear
+  );
   const
-  TexFormatSize: array [TTexFormat] of Byte = (2, 4, 1);
+    TexFormatSize: array [TTexFormat] of Byte = (2, 4, 1);
+    TexFilter: array [TFilterType] of GLint = (GL_NEAREST, GL_LINEAR);
 
 type
   TRenderMode = (rm2D, rm3D);
@@ -36,8 +41,8 @@ type
     procedure SetRenderMode(aRenderMode: TRenderMode); //Switch between 2D and 3D perspectives
 
     class function GetMaxTexSize: Integer;
-    class function GenerateTextureCommon: GLuint;
-    class function GenTexture(DestX, DestY: Word; const Data: Pointer; Mode: TTexFormat): GLUint;
+    class function GenerateTextureCommon(aMinFilter, aMagFilter: TFilterType): GLuint;
+    class function GenTexture(DestX, DestY: Word; const Data: Pointer; Mode: TTexFormat; aMinFilter, aMagFilter: TFilterType): GLUint;
     class procedure DeleteTexture(aTex: GLUint);
     class procedure UpdateTexture(aTexture: GLuint; DestX, DestY: Word; Mode: TTexFormat; const Data: Pointer);
     class procedure BindTexture(aTexId: Cardinal);
@@ -169,9 +174,10 @@ begin
 end;
 
 
-class function TRender.GenerateTextureCommon: GLuint;
+class function TRender.GenerateTextureCommon(aMinFilter, aMagFilter: TFilterType): GLuint;
 var
   Texture: GLuint;
+  MagFilter: GLint;
 begin
   Result := 0;
   if not Assigned(glGenTextures) then Exit;
@@ -185,9 +191,9 @@ begin
   //GL_REPLACE is also available since version 1.1
   //can't use GL_REPLACE cos it disallows blending of texture with custom color (e.g. trees in FOW)
 
-  {Keep original KaM grainy look}
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  {Use nearest filter to keep original KaM grainy look}
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, TexFilter[aMinFilter]);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, TexFilter[aMagFilter]);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 
   {Clamping UVs solves edge artifacts}
@@ -198,9 +204,9 @@ end;
 
 
 //Generate texture out of TCardinalArray
-class function TRender.GenTexture(DestX, DestY: Word; const Data: Pointer; Mode: TTexFormat): GLUint;
+class function TRender.GenTexture(DestX, DestY: Word; const Data: Pointer; Mode: TTexFormat; aMinFilter, aMagFilter: TFilterType): GLUint;
 begin
-  Result := GenerateTextureCommon;
+  Result := GenerateTextureCommon(aMinFilter, aMagFilter);
   UpdateTexture(Result, DestX, DestY, Mode, Data);
 end;
 

--- a/src/render/KM_Render.pas
+++ b/src/render/KM_Render.pas
@@ -177,7 +177,6 @@ end;
 class function TRender.GenerateTextureCommon(aMinFilter, aMagFilter: TFilterType): GLuint;
 var
   Texture: GLuint;
-  MagFilter: GLint;
 begin
   Result := 0;
   if not Assigned(glGenTextures) then Exit;

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -1152,6 +1152,9 @@ begin
   if not aForced and (gMySpectator.FogOfWar.CheckVerticeRenderRev(X,Y) <= FOG_OF_WAR_MIN) then
     Exit;
 
+  pX := RoundToTilePixel(pX);
+  pY := RoundToTilePixel(pY);
+
   with gGFXData[aRX, aId] do
   begin
     // FOW is rendered over the top so no need to make sprites black anymore
@@ -1199,7 +1202,13 @@ begin
   if (gMySpectator.FogOfWar.CheckVerticeRenderRev(X,Y) <= FOG_OF_WAR_MIN) then Exit;
   // Skip rendering if alphas are zero (occurs so non-started houses can still have child sprites)
   if (aWoodProgress = 0) and (aStoneProgress = 0) then Exit;
-  
+
+  pX := RoundToTilePixel(pX);
+  pY := RoundToTilePixel(pY);
+
+  X2 := RoundToTilePixel(X2);
+  Y2 := RoundToTilePixel(Y2);
+
   glClear(GL_STENCIL_BUFFER_BIT);
 
   // Setup stencil mask

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -167,8 +167,8 @@ end;
 
 function RoundToTilePixel(aVal: TKMPointF): TKMPointF; inline; overload;
 begin
-  Result.X := Round(aVal.X * CELL_SIZE_PX) / CELL_SIZE_PX;
-  Result.Y := Round(aVal.Y * CELL_SIZE_PX) / CELL_SIZE_PX;
+  Result.X := RoundToTilePixel(aVal.X);
+  Result.Y := RoundToTilePixel(aVal.Y);
 end;
 
 

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -159,6 +159,19 @@ const
   DELETE_COLOR = $1616FF;
 
 
+function RoundToTilePixel(aVal: Single): Single; inline; overload;
+begin
+  Result := Round(aVal * CELL_SIZE_PX) / CELL_SIZE_PX;
+end;
+
+
+function RoundToTilePixel(aVal: TKMPointF): TKMPointF; inline; overload;
+begin
+  Result.X := Round(aVal.X * CELL_SIZE_PX) / CELL_SIZE_PX;
+  Result.Y := Round(aVal.Y * CELL_SIZE_PX) / CELL_SIZE_PX;
+end;
+
+
 constructor TRenderPool.Create(aViewport: TKMViewport; aRender: TRender);
 var
   RT: TRXType;
@@ -212,7 +225,12 @@ end;
 
 
 procedure TRenderPool.ApplyTransform;
+var
+  ViewportPosRound: TKMPointF;
 begin
+  //Need to round the viewport position so we only translate by whole pixels
+  ViewportPosRound := RoundToTilePixel(fViewport.Position);
+
   glLoadIdentity; // Reset The View
 
   //Use integer division so we don't translate by half a pixel if clip is odd
@@ -220,7 +238,7 @@ begin
 
   glScalef(fViewport.Zoom*CELL_SIZE_PX, fViewport.Zoom*CELL_SIZE_PX, 1 / 256);
 
-  glTranslatef(-fViewport.Position.X + gGame.ActiveInterface.ToolbarWidth/CELL_SIZE_PX/fViewport.Zoom, -fViewport.Position.Y, 0);
+  glTranslatef(-ViewportPosRound.X + gGame.ActiveInterface.ToolbarWidth/CELL_SIZE_PX/fViewport.Zoom, -ViewportPosRound.Y, 0);
 
   if RENDER_3D then
   begin
@@ -230,14 +248,14 @@ begin
     glRotatef(rHeading,1,0,0);
     glRotatef(rPitch  ,0,1,0);
     glRotatef(rBank   ,0,0,1);
-    glTranslatef(-fViewport.Position.X + gGame.ActiveInterface.ToolBarWidth/CELL_SIZE_PX/fViewport.Zoom, -fViewport.Position.Y - 8, 10);
+    glTranslatef(-ViewportPosRound.X + gGame.ActiveInterface.ToolBarWidth/CELL_SIZE_PX/fViewport.Zoom, -ViewportPosRound.Y - 8, 10);
     glScalef(fViewport.Zoom, fViewport.Zoom, 1);
   end;
 
   glRotatef(rHeading,1,0,0);
   glRotatef(rPitch  ,0,1,0);
   glRotatef(rBank   ,0,0,1);
-  glTranslatef(0, 0, -fViewport.Position.Y);
+  glTranslatef(0, 0, -ViewportPosRound.Y);
 end;
 
 

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -214,7 +214,10 @@ end;
 procedure TRenderPool.ApplyTransform;
 begin
   glLoadIdentity; // Reset The View
-  glTranslatef(fViewport.ViewportClip.X/2, fViewport.ViewportClip.Y/2, 0);
+
+  //Use integer division so we don't translate by half a pixel if clip is odd
+  glTranslatef(fViewport.ViewportClip.X div 2, fViewport.ViewportClip.Y div 2, 0);
+
   glScalef(fViewport.Zoom*CELL_SIZE_PX, fViewport.Zoom*CELL_SIZE_PX, 1 / 256);
 
   glTranslatef(-fViewport.Position.X + gGame.ActiveInterface.ToolbarWidth/CELL_SIZE_PX/fViewport.Zoom, -fViewport.Position.Y, 0);

--- a/src/render/KM_RenderTerrain.pas
+++ b/src/render/KM_RenderTerrain.pas
@@ -135,14 +135,14 @@ begin
   for I := 0 to 255 do
     pData[I] := EnsureRange(Round(I * 1.0625 - 16), 0, 255) * 65793 or $FF000000;
 
-  fTextG := TRender.GenTexture(256, 1, @pData[0], tfRGBA8);
+  fTextG := TRender.GenTexture(256, 1, @pData[0], tfRGBA8, ftNearest, ftNearest);
 
   //Sharp transition between black and white
   pData[0] := $FF000000;
   pData[1] := $00000000;
   pData[2] := $00000000;
   pData[3] := $00000000;
-  fTextB := TRender.GenTexture(4, 1, @pData[0], tfRGBA8);
+  fTextB := TRender.GenTexture(4, 1, @pData[0], tfRGBA8, ftNearest, ftNearest);
 
   fUseVBO := DoUseVBO;
 

--- a/src/res/KM_ResFonts.pas
+++ b/src/res/KM_ResFonts.pas
@@ -316,7 +316,7 @@ begin
     if fAtlases[I].TexID = 0 then //Don't load atlases twice if switching from minimal to full
       if Length(fAtlases[I].TexData) <> 0 then
       begin
-        fAtlases[I].TexID := TRender.GenTexture(fTexSizeX, fTexSizeY, @fAtlases[I].TexData[0], aTexMode);
+        fAtlases[I].TexID := TRender.GenTexture(fTexSizeX, fTexSizeY, @fAtlases[I].TexData[0], aTexMode, ftNearest, ftNearest);
         Inc(TextureRAM, fTexSizeX * fTexSizeY * TexFormatSize[aTexMode]);
       end
       else

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -896,6 +896,7 @@ procedure TKMSpritePack.MakeGFX_BinPacking(aTexType: TTexFormat; aStartingIndex:
     Tx: Cardinal;
     ID: Word;
     TD: TKMCardinalArray;
+    TexFilter: TFilterType;
   begin
     //Prepare atlases
     for I := 0 to High(SpriteInfo) do
@@ -959,7 +960,11 @@ procedure TKMSpritePack.MakeGFX_BinPacking(aTexType: TTexFormat; aStartingIndex:
       if aFillGFXData then
       begin
         //Generate texture once
-        Tx := TRender.GenTexture(SpriteInfo[I].Width, SpriteInfo[I].Height, @TD[0], aTexType, ftNearest, ftNearest);
+        TexFilter := ftNearest;
+        if LINEAR_FILTER_SPRITES and (fRT in [rxTrees, rxHouses, rxUnits]) then
+          TexFilter := ftLinear;
+
+        Tx := TRender.GenTexture(SpriteInfo[I].Width, SpriteInfo[I].Height, @TD[0], aTexType, TexFilter, TexFilter);
         //Now that we know texture IDs we can fill GFXData structure
         SetGFXData(Tx, SpriteInfo[I], aMode, Self, fRT);
       end else begin
@@ -1425,6 +1430,7 @@ var
   SAT: TSpriteAtlasType;
   Tx: Cardinal;
   SpritesPack: TKMSpritePack;
+  TexFilter: TFilterType;
 begin
   SpritesPack := GetSprites(aRT);
   for SAT := Low(TSpriteAtlasType) to High(TSpriteAtlasType) do
@@ -1432,7 +1438,11 @@ begin
     begin
       with gGFXPrepData[SAT,I] do
       begin
-        Tx := TRender.GenTexture(SpriteInfo.Width, SpriteInfo.Height, @Data[0], TexType, ftNearest, ftNearest);
+        TexFilter := ftNearest;
+        if LINEAR_FILTER_SPRITES and (aRT in [rxTrees, rxHouses, rxUnits]) then
+          TexFilter := ftLinear;
+
+        Tx := TRender.GenTexture(SpriteInfo.Width, SpriteInfo.Height, @Data[0], TexType, TexFilter, TexFilter);
         //Now that we know texture IDs we can fill GFXData structure
         SetGFXData(Tx, SpriteInfo, SAT, SpritesPack, aRT);
 

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -959,7 +959,7 @@ procedure TKMSpritePack.MakeGFX_BinPacking(aTexType: TTexFormat; aStartingIndex:
       if aFillGFXData then
       begin
         //Generate texture once
-        Tx := TRender.GenTexture(SpriteInfo[I].Width, SpriteInfo[I].Height, @TD[0], aTexType);
+        Tx := TRender.GenTexture(SpriteInfo[I].Width, SpriteInfo[I].Height, @TD[0], aTexType, ftNearest, ftNearest);
         //Now that we know texture IDs we can fill GFXData structure
         SetGFXData(Tx, SpriteInfo[I], aMode, Self, fRT);
       end else begin
@@ -1432,7 +1432,7 @@ begin
     begin
       with gGFXPrepData[SAT,I] do
       begin
-        Tx := TRender.GenTexture(SpriteInfo.Width, SpriteInfo.Height, @Data[0], TexType);
+        Tx := TRender.GenTexture(SpriteInfo.Width, SpriteInfo.Height, @Data[0], TexType, ftNearest, ftNearest);
         //Now that we know texture IDs we can fill GFXData structure
         SetGFXData(Tx, SpriteInfo, SAT, SpritesPack, aRT);
 


### PR DESCRIPTION
Thanks to Krom's help and patience I've had another go at fixing the sprite bouncing (less hasty this time). @Kromster80 can you please review this when you have time? @reyandme please wait for Krom to have a look before merging.

Based on our discussion last night and reading the links you sent me, I guessed the problem is that sprites are not being rendered aligned to whole screen pixels, so sometimes due to rounding errors it samples from the wrong position.

In order to visualize this problem I added a debug boolean LINEAR_FILTER_SPRITES which filters rxTrees, rxUnits, and rxHouses atlases with GL_LINEAR. This means if sprites are not being sampled from pixel centers they will appear blurry (if sampled from center they will appear as normal). Sure enough, there's a vertical blur on most sprites with this option enabled. Since it depends on the land height, each sprite has a different amount of blur. The animation has stopped bouncing in my reproducible case as expected, but 1px lines from the neighboring atlas sprite are still visible.

AFAIK to keep sprites perfectly aligned to screen pixels two things must be true:
1. Viewport offset must be in whole pixels (glTranslatef calls)
2. Sprite position must be in whole pixels (glVertex2f calls)

After adding rounding to the relevant places, the sprites no longer look blurry with LINEAR_FILTER_SPRITES enabled (screenshot is the same in GIMP with it on/off).

The bouncing animation has also stopped bouncing in the reproducible case and there are no 1px lines around it.