### PR TITLE
Game resources were being reloaded the second time you start game

### DIFF
--- a/src/res/KM_Resource.pas
+++ b/src/res/KM_Resource.pas
@@ -243,11 +243,8 @@ begin
   if (fDataState <> rlsAll) or DoForceReload then
   begin
     fSprites.LoadGameResources(aAlphaShadows, DoForceReload);
-    if not DoForceReload then
-    begin
-      fDataState := rlsAll;
-      fSprites.ClearTemp;
-    end;
+    fDataState := rlsAll;
+    fSprites.ClearTemp;
   end;
 
   gLog.AddTime('Resource loading state - Game');


### PR DESCRIPTION
I noticed starting a mission was still taking a long time the second time after returning to menu, then I found this bug.

@reyandme Any idea why this check was there? It seems incorrect. Possibly to do with async loading? I see no reason not to update fDataState and delete temp buffers even if we are doing a forced reload.