### PR TITLE
Interpolated render

### DIFF
--- a/KaM_Remake.dpr
+++ b/KaM_Remake.dpr
@@ -306,6 +306,7 @@ uses
   KM_UnitGroup in 'src\units\KM_UnitGroup.pas',
   KM_Units in 'src\units\KM_Units.pas',
   KM_UnitsCollection in 'src\units\KM_UnitsCollection.pas',
+  KM_UnitVisual in 'src\units\KM_UnitVisual.pas',
   KM_UnitWarrior in 'src\units\KM_UnitWarrior.pas',
   KM_UnitWorkPlan in 'src\units\KM_UnitWorkPlan.pas',
   

--- a/KaM_Remake.dproj
+++ b/KaM_Remake.dproj
@@ -374,6 +374,7 @@
         <DCCReference Include="src\units\KM_UnitGroup.pas"/>
         <DCCReference Include="src\units\KM_Units.pas"/>
         <DCCReference Include="src\units\KM_UnitsCollection.pas"/>
+        <DCCReference Include="src\units\KM_UnitVisual.pas"/>
         <DCCReference Include="src\units\KM_UnitWarrior.pas"/>
         <DCCReference Include="src\units\KM_UnitWorkPlan.pas"/>
         <DCCReference Include="src\units\tasks\KM_UnitTaskAttackHouse.pas"/>

--- a/src/KM_Projectiles.pas
+++ b/src/KM_Projectiles.pas
@@ -43,7 +43,7 @@ type
     function AimTarget(const aStart: TKMPointF; aTarget: TKMHouse; aProjType: TKMProjectileType; aOwner: TKMUnit; aMaxRange,aMinRange: Single):word; overload;
 
     procedure UpdateState;
-    procedure Paint;
+    procedure Paint(aSubTick: Single);
 
     procedure Save(SaveStream: TKMemoryStream);
     procedure Load(LoadStream: TKMemoryStream);
@@ -328,10 +328,10 @@ begin
 end;
 
 
-procedure TKMProjectiles.Paint;
+procedure TKMProjectiles.Paint(aSubTick: Single);
 var
   I: Integer;
-  MixValue,MixValueMax: Single;
+  MixValue, MixValueMax, SubOffset: Single;
   MixArc: Single; //mix Arc shape
   P: TKMPointF; //Arrows and bolts send 2 points for head and tail
   PTileBased: TKMPointF;
@@ -340,9 +340,12 @@ begin
   for I := 0 to Length(fItems) - 1 do
     if (fItems[I].fSpeed <> 0) and ProjectileVisible(I) then
     begin
+      SubOffset := aSubTick*fItems[I].fSpeed / fItems[I].fLength;
 
       MixValue := fItems[I].fPosition / fItems[I].fLength; // 0 >> 1
+      MixValue := Math.Min(MixValue + SubOffset, 1.0);
       MixValueMax := fItems[I].fPosition / fItems[I].fMaxLength; // 0 >> 1
+      MixValueMax := Math.Min(MixValueMax + SubOffset, 1.0);
       P := KMLerp(fItems[I].fScreenStart, fItems[I].fScreenEnd, MixValue);
       PTileBased := KMLerp(fItems[I].fShotFrom, fItems[I].fTarget, MixValue);
       case fItems[I].fType of

--- a/src/KM_Projectiles.pas
+++ b/src/KM_Projectiles.pas
@@ -340,12 +340,9 @@ begin
   for I := 0 to Length(fItems) - 1 do
     if (fItems[I].fSpeed <> 0) and ProjectileVisible(I) then
     begin
-      SubOffset := aSubTick*fItems[I].fSpeed / fItems[I].fLength;
-
-      MixValue := fItems[I].fPosition / fItems[I].fLength; // 0 >> 1
-      MixValue := Math.Min(MixValue + SubOffset, 1.0);
-      MixValueMax := fItems[I].fPosition / fItems[I].fMaxLength; // 0 >> 1
-      MixValueMax := Math.Min(MixValueMax + SubOffset, 1.0);
+      SubOffset := aSubTick*fItems[I].fSpeed;
+      MixValue := Math.Min((fItems[I].fPosition + SubOffset) / fItems[I].fLength, 1.0); // 0 >> 1
+      MixValueMax := Math.Min((fItems[I].fPosition + SubOffset) / fItems[I].fMaxLength, 1.0); // 0 >> 1
       P := KMLerp(fItems[I].fScreenStart, fItems[I].fScreenEnd, MixValue);
       PTileBased := KMLerp(fItems[I].fShotFrom, fItems[I].fTarget, MixValue);
       case fItems[I].fType of

--- a/src/common/KM_Defaults.pas
+++ b/src/common/KM_Defaults.pas
@@ -85,7 +85,7 @@ var
   SHOW_DISMISS_GROUP_BTN:Boolean = False; //The button to kill group
   CHECK_8087CW          :Boolean = False; //Check that 8087CW (FPU flags) are set correctly each frame, in case some lib/API changed them
   SCROLL_ACCEL          :Boolean = False; //Acceleration for viewport scrolling
-  INTERPOLATED_RENDER   :Boolean = True; //Interpolate positions/animations in render between game ticks
+  INTERPOLATED_RENDER   :Boolean = False; //Interpolate positions/animations in render between game ticks
   PathFinderToUse       :Byte = 1;
 
   //Cache / delivery / pathfinding

--- a/src/common/KM_Defaults.pas
+++ b/src/common/KM_Defaults.pas
@@ -85,6 +85,7 @@ var
   SHOW_DISMISS_GROUP_BTN:Boolean = False; //The button to kill group
   CHECK_8087CW          :Boolean = False; //Check that 8087CW (FPU flags) are set correctly each frame, in case some lib/API changed them
   SCROLL_ACCEL          :Boolean = False; //Acceleration for viewport scrolling
+  INTERPOLATED_RENDER   :Boolean = True; //Interpolate positions/animations in render between game ticks
   PathFinderToUse       :Byte = 1;
 
   //Cache / delivery / pathfinding

--- a/src/game/KM_Game.pas
+++ b/src/game/KM_Game.pas
@@ -1425,13 +1425,19 @@ end;
 
 
 procedure TKMGame.Render(aRender: TRender);
+var t: Single;
 begin
   {$IFDEF PERFLOG}
   gPerfLogs.SectionEnter(psFrameFullC);
   {$ENDIF}
   try
+    t := GetTicksBehindCnt;
+    fSaveWorkerThread.QueueWork(procedure
+    begin
+      gLog.AddTimeNoFlush('Ticks Behind = '+FloatToStr(t));
+    end);
     if DoRenderGame then
-      gRenderPool.Render;
+      gRenderPool.Render(EnsureRange(GetTicksBehindCnt, 0.0, 1.0));
 
     aRender.SetRenderMode(rm2D);
     fActiveInterface.Paint;

--- a/src/game/KM_Game.pas
+++ b/src/game/KM_Game.pas
@@ -1433,9 +1433,14 @@ begin
   {$ENDIF}
   try
     //How far in the past should we render? (0.0=Current tick, 1.0=Previous tick)
-    tickLag := GetTimeSince(fLastUpdateState) / fGameSpeedActual / gGameApp.GameSettings.SpeedPace;
-    tickLag := 1.0 - tickLag;
-    tickLag := EnsureRange(tickLag, 0.0, 1.0);
+    if INTERPOLATED_RENDER then
+    begin
+      tickLag := GetTimeSince(fLastUpdateState) / fGameSpeedActual / gGameApp.GameSettings.SpeedPace;
+      tickLag := 1.0 - tickLag;
+      tickLag := EnsureRange(tickLag, 0.0, 1.0);
+    end
+    else
+      tickLag := 0.0;
 
     if DoRenderGame then
       gRenderPool.Render(tickLag);

--- a/src/hands/KM_Hand.pas
+++ b/src/hands/KM_Hand.pas
@@ -43,7 +43,7 @@ type
     procedure SyncLoad; virtual;
 
     procedure UpdateState(aTick: Cardinal); virtual;
-    procedure Paint(const aRect: TKMRect); virtual;
+    procedure Paint(const aRect: TKMRect; aTickLag: Single); virtual;
   end;
 
 
@@ -220,7 +220,7 @@ type
     procedure SyncLoad; override;
     procedure IncAnimStep;
     procedure UpdateState(aTick: Cardinal); override;
-    procedure Paint(const aRect: TKMRect); override;
+    procedure Paint(const aRect: TKMRect; aTickLag: Single); override;
     function ObjToString: String;
   end;
 
@@ -272,10 +272,10 @@ begin
 end;
 
 
-procedure TKMHandCommon.Paint(const aRect: TKMRect);
+procedure TKMHandCommon.Paint(const aRect: TKMRect; aTickLag: Single);
 begin
   if mlUnits in gGame.VisibleLayers then
-    fUnits.Paint(aRect);
+    fUnits.Paint(aRect, aTickLag);
 end;
 
 
@@ -2059,7 +2059,7 @@ begin
 end;
 
 
-procedure TKMHand.Paint(const aRect: TKMRect);
+procedure TKMHand.Paint(const aRect: TKMRect; aTickLag: Single);
 begin
   if not Enabled then Exit;
 

--- a/src/hands/KM_HandsCollection.pas
+++ b/src/hands/KM_HandsCollection.pas
@@ -91,7 +91,7 @@ type
     procedure IncAnimStep;
 
     procedure UpdateState(aTick: Cardinal);
-    procedure Paint(const aRect: TKMRect);
+    procedure Paint(const aRect: TKMRect; aTickLag: Single);
     function ObjToString: String;
 
     procedure ExportGameStatsToCSV(const aPath: String; const aHeader: String = '');
@@ -1177,14 +1177,14 @@ begin
 end;
 
 
-procedure TKMHandsCollection.Paint(const aRect: TKMRect);
+procedure TKMHandsCollection.Paint(const aRect: TKMRect; aTickLag: Single);
 var
   I: Integer;
 begin
   for I := 0 to fCount - 1 do
-    fHandsList[I].Paint(aRect);
+    fHandsList[I].Paint(aRect, aTickLag);
 
-  PlayerAnimals.Paint(aRect);
+  PlayerAnimals.Paint(aRect, aTickLag);
 end;
 
 

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -329,7 +329,7 @@ begin
 
     PaintFlagPoints(True);
 
-    gHands.Paint(ClipRect); // Units and houses
+    gHands.Paint(ClipRect, aTickLag); // Units and houses
     gProjectiles.Paint(aTickLag);
 
     if gGame.GamePlayInterface <> nil then

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -142,7 +142,7 @@ type
     property RenderTerrain: TRenderTerrain read fRenderTerrain;
     procedure SetRotation(aH,aP,aB: Integer);
 
-    procedure Render;
+    procedure Render(aSubTick: Single);
   end;
 
 
@@ -271,7 +271,7 @@ end;
 // 2. Renders terrain
 // 3. Polls Game objects to add themselves to RenderList through Add** methods
 // 4. Renders cursor highlights
-procedure TRenderPool.Render;
+procedure TRenderPool.Render(aSubTick: Single);
 var
   ClipRect: TKMRect;
 begin
@@ -330,7 +330,7 @@ begin
     PaintFlagPoints(True);
 
     gHands.Paint(ClipRect); // Units and houses
-    gProjectiles.Paint;
+    gProjectiles.Paint(aSubTick);
 
     if gGame.GamePlayInterface <> nil then
       gGame.GamePlayInterface.Alerts.Paint(0);

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -142,7 +142,7 @@ type
     property RenderTerrain: TRenderTerrain read fRenderTerrain;
     procedure SetRotation(aH,aP,aB: Integer);
 
-    procedure Render(aSubTick: Single);
+    procedure Render(aTickLag: Single);
   end;
 
 
@@ -271,7 +271,7 @@ end;
 // 2. Renders terrain
 // 3. Polls Game objects to add themselves to RenderList through Add** methods
 // 4. Renders cursor highlights
-procedure TRenderPool.Render(aSubTick: Single);
+procedure TRenderPool.Render(aTickLag: Single);
 var
   ClipRect: TKMRect;
 begin
@@ -330,7 +330,7 @@ begin
     PaintFlagPoints(True);
 
     gHands.Paint(ClipRect); // Units and houses
-    gProjectiles.Paint(aSubTick);
+    gProjectiles.Paint(aTickLag);
 
     if gGame.GamePlayInterface <> nil then
       gGame.GamePlayInterface.Alerts.Paint(0);

--- a/src/units/KM_UnitVisual.pas
+++ b/src/units/KM_UnitVisual.pas
@@ -61,7 +61,6 @@ begin
   Result.PosF := KMLerp(A.PosF, B.PosF, Mix);
   Result.SlideX := KromUtils.Lerp(A.SlideX, B.SlideX, Mix);
   Result.SlideY := KromUtils.Lerp(A.SlideY, B.SlideY, Mix);
-  Result.PosF := KMLerp(A.PosF, B.PosF, Mix);
   if Mix < 0.5 then
   begin
     Result.Dir := A.Dir;

--- a/src/units/KM_UnitVisual.pas
+++ b/src/units/KM_UnitVisual.pas
@@ -11,7 +11,10 @@ type
     SlideX, SlideY: Single;
     Action: TKMUnitActionType;
     AnimStep: Integer;
+
     procedure SetFromUnit(aUnit: TObject);
+
+    class function Lerp(const A, B: TKMUnitVisualState; Mix: Single): TKMUnitVisualState; static;
   end;
 
   // Purely visual thing. Split from TKMUnit to aviod mixup of game-logic and render Positions
@@ -23,6 +26,7 @@ type
   public
     constructor Create(aUnit: TObject);
 
+    function GetLerp(aLag: Single): TKMUnitVisualState;
     procedure UpdateState;
   end;
 
@@ -52,6 +56,27 @@ begin
 end;
 
 
+class function TKMUnitVisualState.Lerp(const A, B: TKMUnitVisualState; Mix: Single): TKMUnitVisualState;
+begin
+  Result.PosF := KMLerp(A.PosF, B.PosF, Mix);
+  Result.SlideX := KromUtils.Lerp(A.SlideX, B.SlideX, Mix);
+  Result.SlideY := KromUtils.Lerp(A.SlideY, B.SlideY, Mix);
+  Result.PosF := KMLerp(A.PosF, B.PosF, Mix);
+  if Mix < 0.5 then
+  begin
+    Result.Dir := A.Dir;
+    Result.AnimStep := A.AnimStep;
+    Result.Action := A.Action;
+  end
+  else
+  begin
+    Result.Dir := B.Dir;
+    Result.AnimStep := B.AnimStep;
+    Result.Action := B.Action;
+  end;
+end;
+
+
 { TKMUnitVisual }
 constructor TKMUnitVisual.Create(aUnit: TObject);
 begin
@@ -59,6 +84,12 @@ begin
   fUnit := TKMUnit(aUnit);
   Prev.SetFromUnit(fUnit);
   Curr.SetFromUnit(fUnit);
+end;
+
+
+function TKMUnitVisual.GetLerp(aLag: Single): TKMUnitVisualState;
+begin
+  Result := TKMUnitVisualState.Lerp(Curr, Prev, aLag);
 end;
 
 

--- a/src/units/KM_UnitVisual.pas
+++ b/src/units/KM_UnitVisual.pas
@@ -2,13 +2,23 @@ unit KM_UnitVisual;
 {$I KaM_Remake.inc}
 interface
 uses
-  KM_CommonSave, KM_Points;
+  KM_Points, KM_Defaults;
 
 type
+  TKMUnitVisualState = record
+    PosF: TKMPointF;
+    Dir: TKMDirection;
+    SlideX, SlideY: Single;
+    Action: TKMUnitActionType;
+    AnimStep: Integer;
+  end;
+
   // Purely visual thing. Split from TKMUnit to aviod mixup of game-logic and render Positions
   TKMUnitVisual = class
   private
     fUnit: TObject;
+    Curr: TKMUnitVisualState;
+    Prev: TKMUnitVisualState;
   public
     constructor Create(aUnit: TObject);
 
@@ -26,14 +36,22 @@ uses
 constructor TKMUnitVisual.Create(aUnit: TObject);
 begin
   inherited Create;
-
-  // Fill in initial values (Unit is nil in PreviewUnit)
-  fUnit := TKMUnit(aUnit).GetUnitPointer;
+  fUnit := TKMUnit(aUnit);
 end;
 
 
 procedure TKMUnitVisual.UpdateState;
+var
+  U: TKMUnit;
 begin
+  U := TKMUnit(fUnit);
+  Prev := Curr;
+  Curr.PosF := U.PositionF;
+  Curr.Dir := U.Direction;
+  Curr.SlideX := U.GetSlide(axX);
+  Curr.SlideY := U.GetSlide(axY);
+  Curr.Action := U.Action;
+  Curr.AnimStep := U.AnimStep;
 end;
 
 

--- a/src/units/KM_UnitVisual.pas
+++ b/src/units/KM_UnitVisual.pas
@@ -11,6 +11,7 @@ type
     SlideX, SlideY: Single;
     Action: TKMUnitActionType;
     AnimStep: Integer;
+    procedure SetFromUnit(aUnit: TObject);
   end;
 
   // Purely visual thing. Split from TKMUnit to aviod mixup of game-logic and render Positions
@@ -32,31 +33,39 @@ uses
   KM_Units, KM_Game, KM_Terrain;
 
 
+{ TKMUnitVisualState }
+procedure TKMUnitVisualState.SetFromUnit(aUnit: TObject);
+var
+  U: TKMUnit;
+begin
+  U := TKMUnit(aUnit);
+  PosF := U.PositionF;
+  Dir := U.Direction;
+  SlideX := U.GetSlide(axX);
+  SlideY := U.GetSlide(axY);
+  AnimStep := U.AnimStep;
+
+  if U.Action <> nil then
+    Action := U.Action.ActionType
+  else
+    Action := uaUnknown;
+end;
+
+
 { TKMUnitVisual }
 constructor TKMUnitVisual.Create(aUnit: TObject);
 begin
   inherited Create;
   fUnit := TKMUnit(aUnit);
+  Prev.SetFromUnit(fUnit);
+  Curr.SetFromUnit(fUnit);
 end;
 
 
 procedure TKMUnitVisual.UpdateState;
-var
-  U: TKMUnit;
 begin
-  U := TKMUnit(fUnit);
   Prev := Curr;
-  Curr.PosF := U.PositionF;
-  Curr.Dir := U.Direction;
-  Curr.SlideX := U.GetSlide(axX);
-  Curr.SlideY := U.GetSlide(axY);
-  Curr.AnimStep := U.AnimStep;
-
-  if U.Action <> nil then
-    Curr.Action := U.Action.ActionType
-  else
-    Curr.Action := uaUnknown;
+  Curr.SetFromUnit(fUnit);
 end;
-
 
 end.

--- a/src/units/KM_UnitVisual.pas
+++ b/src/units/KM_UnitVisual.pas
@@ -29,7 +29,7 @@ type
 implementation
 uses
   KromUtils, Math, SysUtils,
-  KM_Defaults, KM_Units, KM_Game, KM_Terrain;
+  KM_Units, KM_Game, KM_Terrain;
 
 
 { TKMUnitVisual }
@@ -50,8 +50,12 @@ begin
   Curr.Dir := U.Direction;
   Curr.SlideX := U.GetSlide(axX);
   Curr.SlideY := U.GetSlide(axY);
-  Curr.Action := U.Action;
   Curr.AnimStep := U.AnimStep;
+
+  if U.Action <> nil then
+    Curr.Action := U.Action.ActionType
+  else
+    Curr.Action := uaUnknown;
 end;
 
 

--- a/src/units/KM_UnitVisual.pas
+++ b/src/units/KM_UnitVisual.pas
@@ -1,0 +1,40 @@
+unit KM_UnitVisual;
+{$I KaM_Remake.inc}
+interface
+uses
+  KM_CommonSave, KM_Points;
+
+type
+  // Purely visual thing. Split from TKMUnit to aviod mixup of game-logic and render Positions
+  TKMUnitVisual = class
+  private
+    fUnit: TObject;
+  public
+    constructor Create(aUnit: TObject);
+
+    procedure UpdateState;
+  end;
+
+
+implementation
+uses
+  KromUtils, Math, SysUtils,
+  KM_Defaults, KM_Units, KM_Game, KM_Terrain;
+
+
+{ TKMUnitVisual }
+constructor TKMUnitVisual.Create(aUnit: TObject);
+begin
+  inherited Create;
+
+  // Fill in initial values (Unit is nil in PreviewUnit)
+  fUnit := TKMUnit(aUnit).GetUnitPointer;
+end;
+
+
+procedure TKMUnitVisual.UpdateState;
+begin
+end;
+
+
+end.

--- a/src/units/KM_UnitWarrior.pas
+++ b/src/units/KM_UnitWarrior.pas
@@ -118,7 +118,7 @@ type
 
     procedure Save(SaveStream: TKMemoryStream); override;
     function UpdateState: Boolean; override;
-    procedure Paint; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
 
@@ -1010,7 +1010,7 @@ begin
 end;
 
 
-procedure TKMUnitWarrior.Paint;
+procedure TKMUnitWarrior.Paint(aTickLag: Single);
 var
   Act: TKMUnitActionType;
   UnitPos: TKMPointF;

--- a/src/units/KM_UnitWarrior.pas
+++ b/src/units/KM_UnitWarrior.pas
@@ -128,7 +128,7 @@ uses
   KM_ResTexts, KM_HandsCollection, KM_RenderPool, KM_UnitTaskAttackHouse, KM_HandLogistics,
   KM_UnitActionFight, KM_UnitActionGoInOut, KM_UnitActionWalkTo, KM_UnitActionStay,
   KM_UnitActionStormAttack, KM_Resource, KM_ResUnits, KM_Hand, KM_UnitGroup,
-  KM_ResWares, KM_Game, KM_ResHouses, KM_CommonUtils, KM_RenderDebug;
+  KM_ResWares, KM_Game, KM_ResHouses, KM_CommonUtils, KM_RenderDebug, KM_UnitVisual;
 
 
 { TKMUnitWarrior }
@@ -1012,21 +1012,23 @@ end;
 
 procedure TKMUnitWarrior.Paint(aTickLag: Single);
 var
+  V: TKMUnitVisualState;
   Act: TKMUnitActionType;
   UnitPos: TKMPointF;
   fillColor, lineColor: Cardinal;
 begin
   inherited;
   if not fVisible then Exit;
+  V := fVisual.GetLerp(aTickLag);
 
-  Act := fAction.ActionType;
-  UnitPos.X := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  UnitPos.Y := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
+  Act := V.Action;
+  UnitPos.X := V.PosF.X + UNIT_OFF_X + V.SlideX;
+  UnitPos.Y := V.PosF.Y + UNIT_OFF_Y + V.SlideY;
 
-  gRenderPool.AddUnit(fType, fUID, Act, Direction, AnimStep, UnitPos.X, UnitPos.Y, gHands[fOwner].GameFlagColor, True);
+  gRenderPool.AddUnit(fType, fUID, Act, V.Dir, V.AnimStep, UnitPos.X, UnitPos.Y, gHands[fOwner].GameFlagColor, True);
 
   if fThought <> thNone then
-    gRenderPool.AddUnitThought(fType, Act, Direction, fThought, UnitPos.X, UnitPos.Y);
+    gRenderPool.AddUnitThought(fType, Act, V.Dir, fThought, UnitPos.X, UnitPos.Y);
 
   if SHOW_ATTACK_RADIUS or (mlUnitsAttackRadius in gGame.VisibleLayers) then
     if IsRanged then

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -265,6 +265,7 @@ type
     procedure ProceedHouseClosedForWorker;
   public
     function UpdateState: Boolean; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
   //This is a common class for all units, who can work in house
@@ -274,7 +275,6 @@ type
   public
     function CanWorkAt(aLoc: TKMPoint; aGatheringScript: TKMGatheringScript): Boolean;
     function GetActivityText: UnicodeString; override;
-    procedure Paint(aTickLag: Single); override;
   end;
 
 
@@ -282,7 +282,6 @@ type
   protected
     function InitiateActivity: TKMUnitTask; override;
   public
-    procedure Paint(aTickLag: Single); override;
   end;
 
   //Serf - transports all wares between houses
@@ -434,6 +433,43 @@ begin
 end;
 
 
+procedure TKMSettledUnit.Paint(aTickLag: Single);
+var
+  Act: TKMUnitActionType;
+  XPaintPos, YPaintPos: Single;
+  ID: Integer;
+begin
+  inherited;
+  if not fVisible then exit;
+  if fAction = nil then exit;
+  Act := fAction.fType;
+
+  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
+  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
+
+  ID := fUID * Byte(not (fAction.fType in [uaDie, uaEat]));
+
+  case fAction.fType of
+    uaWalk:
+      begin
+        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+        if gRes.Units[fType].SupportsAction(uaWalkArm) then
+          gRenderPool.AddUnit(fType, ID, uaWalkArm, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
+      end;
+    uaWork..uaEat:
+        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+    uaWalkArm .. uaWalkBooty2:
+      begin
+        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
+      end;
+  end;
+
+  if fThought <> thNone then
+    gRenderPool.AddUnitThought(fType, Act, Direction, fThought, XPaintPos, YPaintPos);
+end;
+
+
 // Manage house is closed for worker process
 procedure TKMSettledUnit.ProceedHouseClosedForWorker;
 var
@@ -569,43 +605,6 @@ end;
 
 
 { TKMUnitCitizen }
-procedure TKMUnitCitizen.Paint(aTickLag: Single);
-var
-  Act: TKMUnitActionType;
-  XPaintPos, YPaintPos: Single;
-  ID: Integer;
-begin
-  inherited;
-  if not fVisible then exit;
-  if fAction = nil then exit;
-  Act := fAction.fType;
-
-  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
-
-  ID := fUID * Byte(not (fAction.fType in [uaDie, uaEat]));
-
-  case fAction.fType of
-    uaWalk:
-      begin
-        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-        if gRes.Units[fType].SupportsAction(uaWalkArm) then
-          gRenderPool.AddUnit(fType, ID, uaWalkArm, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
-      end;
-    uaWork..uaEat:
-        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-    uaWalkArm .. uaWalkBooty2:
-      begin
-        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
-      end;
-  end;
-
-  if fThought <> thNone then
-    gRenderPool.AddUnitThought(fType, Act, Direction, fThought, XPaintPos, YPaintPos);
-end;
-
-
 function TKMUnitCitizen.CanWorkAt(aLoc: TKMPoint; aGatheringScript: TKMGatheringScript): Boolean;
 var
   I: Integer;
@@ -690,43 +689,6 @@ end;
 
 
 { TKMUnitRecruit }
-procedure TKMUnitRecruit.Paint(aTickLag: Single);
-var
-  Act: TKMUnitActionType;
-  XPaintPos, YPaintPos: Single;
-  ID: Integer;
-begin
-  inherited;
-  if not fVisible then exit;
-  if fAction = nil then exit;
-  Act := fAction.fType;
-
-  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
-
-  ID := fUID * Byte(not (fAction.fType in [uaDie, uaEat]));
-
-  case fAction.fType of
-    uaWalk:
-      begin
-        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-        if gRes.Units[fType].SupportsAction(uaWalkArm) then
-          gRenderPool.AddUnit(fType, ID, uaWalkArm, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
-      end;
-    uaWork..uaEat:
-        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-    uaWalkArm .. uaWalkBooty2:
-      begin
-        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
-      end;
-  end;
-
-  if fThought <> thNone then
-    gRenderPool.AddUnitThought(fType, Act, Direction, fThought, XPaintPos, YPaintPos);
-end;
-
-
 function TKMUnitRecruit.InitiateActivity: TKMUnitTask;
 var
   Enemy: TKMUnit;

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -1257,6 +1257,9 @@ begin
   LoadStream.Read(fDismissASAP);
   LoadStream.Read(Dismissable);
   LoadStream.Read(fLastTimeTrySetActionWalk);
+
+  //Create last so it can initialise with loaded values
+  fVisual := TKMUnitVisual.Create(Self);
 end;
 
 

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -435,6 +435,7 @@ end;
 
 procedure TKMSettledUnit.Paint(aTickLag: Single);
 var
+  V: TKMUnitVisualState;
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: Single;
   ID: Integer;
@@ -442,26 +443,28 @@ begin
   inherited;
   if not fVisible then exit;
   if fAction = nil then exit;
-  Act := fAction.fType;
 
-  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
+  V := fVisual.GetLerp(aTickLag);
+  Act := V.Action;
 
-  ID := fUID * Byte(not (fAction.fType in [uaDie, uaEat]));
+  XPaintPos := V.PosF.X + UNIT_OFF_X + V.SlideX;
+  YPaintPos := V.PosF.Y + UNIT_OFF_Y + V.SlideY;
+
+  ID := fUID * Byte(not (Act in [uaDie, uaEat]));
 
   case fAction.fType of
     uaWalk:
       begin
-        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+        gRenderPool.AddUnit(fType, ID, uaWalk, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, True);
         if gRes.Units[fType].SupportsAction(uaWalkArm) then
-          gRenderPool.AddUnit(fType, ID, uaWalkArm, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
+          gRenderPool.AddUnit(fType, ID, uaWalkArm, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, False);
       end;
     uaWork..uaEat:
-        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+        gRenderPool.AddUnit(fType, ID, Act, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, True);
     uaWalkArm .. uaWalkBooty2:
       begin
-        gRenderPool.AddUnit(fType, ID, uaWalk, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
-        gRenderPool.AddUnit(fType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
+        gRenderPool.AddUnit(fType, ID, uaWalk, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, True);
+        gRenderPool.AddUnit(fType, ID, Act, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, False);
       end;
   end;
 
@@ -774,6 +777,7 @@ end;
 
 procedure TKMUnitSerf.Paint(aTickLag: Single);
 var
+  V: TKMUnitVisualState;
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: Single;
   ID: Integer;
@@ -781,24 +785,26 @@ begin
   inherited;
   if not fVisible then exit;
   if fAction = nil then exit;
-  Act := fAction.fType;
 
-  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
+  V := fVisual.GetLerp(aTickLag);
+  Act := V.Action;
 
-  ID := fUID * Byte(not (fAction.fType in [uaDie, uaEat]));
+  XPaintPos := V.PosF.X + UNIT_OFF_X + V.SlideX;
+  YPaintPos := V.PosF.Y + UNIT_OFF_Y + V.SlideY;
 
-  gRenderPool.AddUnit(UnitType, ID, Act, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+  ID := fUID * Byte(not (Act in [uaDie, uaEat]));
+
+  gRenderPool.AddUnit(UnitType, ID, Act, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
 
   if fTask is TKMTaskDie then Exit; //Do not show unnecessary arms
 
   if Carry <> wtNone then
-    gRenderPool.AddUnitCarry(Carry, ID, Direction, AnimStep, XPaintPos, YPaintPos)
+    gRenderPool.AddUnitCarry(Carry, ID, V.Dir, V.AnimStep, XPaintPos, YPaintPos)
   else
-    gRenderPool.AddUnit(UnitType, ID, uaWalkArm, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
+    gRenderPool.AddUnit(UnitType, ID, uaWalkArm, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, false);
 
   if fThought <> thNone then
-    gRenderPool.AddUnitThought(fType, Act, Direction, fThought, XPaintPos, YPaintPos);
+    gRenderPool.AddUnitThought(fType, Act, V.Dir, fThought, XPaintPos, YPaintPos);
 end;
 
 
@@ -919,22 +925,24 @@ end;
 
 procedure TKMUnitWorker.Paint(aTickLag: Single);
 var
+  V: TKMUnitVisualState;
   XPaintPos, YPaintPos: Single;
   ID: Integer;
 begin
   inherited;
   if not fVisible then exit;
   if fAction = nil then exit;
+  V := fVisual.GetLerp(aTickLag);
 
-  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
+  XPaintPos := V.PosF.X + UNIT_OFF_X + V.SlideX;
+  YPaintPos := V.PosF.Y + UNIT_OFF_Y + V.SlideY;
 
-  ID := fUID * Byte(not (fAction.fType in [uaDie, uaEat]));
+  ID := fUID * Byte(not (V.Action in [uaDie, uaEat]));
 
-  gRenderPool.AddUnit(UnitType, ID, fAction.fType, Direction, AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
+  gRenderPool.AddUnit(UnitType, ID, V.Action, V.Dir, V.AnimStep, XPaintPos, YPaintPos, gHands[fOwner].GameFlagColor, true);
 
   if fThought <> thNone then
-    gRenderPool.AddUnitThought(fType, fAction.ActionType, Direction, fThought, XPaintPos, YPaintPos);
+    gRenderPool.AddUnitThought(fType, V.Action, V.Dir, fThought, XPaintPos, YPaintPos);
 end;
 
 
@@ -1046,21 +1054,23 @@ end;
 //For fish the action is the number of fish in the group
 procedure TKMUnitAnimal.Paint(aTickLag: Single);
 var
+  V: TKMUnitVisualState;
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: single;
 begin
   inherited;
   if fAction = nil then exit;
+  V := fVisual.GetLerp(aTickLag);
 
   Assert((fType <> utFish) or (InRange(fFishCount, 1, 5)));
 
   if fType = utFish then
     Act := FishCountAct[fFishCount]
   else
-    Act := fAction.fType;
+    Act := V.Action;
 
-  XPaintPos := fPositionF.X + UNIT_OFF_X + GetSlide(axX);
-  YPaintPos := fPositionF.Y + UNIT_OFF_Y + GetSlide(axY);
+  XPaintPos := V.PosF.X + UNIT_OFF_X + V.SlideX;
+  YPaintPos := V.PosF.Y + UNIT_OFF_Y + V.SlideY;
 
   //Make fish/watersnakes more visible in the MapEd
   if (gGame.GameMode = gmMapEd) and (fType in [utFish, utWatersnake, utSeastar]) then
@@ -1070,7 +1080,7 @@ begin
 
   //Animals share the same WalkTo logic as other units and they exchange places if necessary
   //Animals can be picked only in MapEd
-  gRenderPool.AddUnit(fType, fUID * Byte(gGame.IsMapEditor), Act, Direction, AnimStep, XPaintPos, YPaintPos, $FFFFFFFF, True);
+  gRenderPool.AddUnit(fType, fUID * Byte(gGame.IsMapEditor), Act, V.Dir, V.AnimStep, XPaintPos, YPaintPos, $FFFFFFFF, True);
 end;
 
 

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -241,7 +241,7 @@ type
 
     procedure Save(SaveStream: TKMemoryStream); virtual;
     function UpdateState: Boolean; virtual;
-    procedure Paint; virtual;
+    procedure Paint(aTickLag: Single); virtual;
 
     class function GetDefaultCondition: Integer;
   end;
@@ -273,7 +273,7 @@ type
   public
     function CanWorkAt(aLoc: TKMPoint; aGatheringScript: TKMGatheringScript): Boolean;
     function GetActivityText: UnicodeString; override;
-    procedure Paint; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
 
@@ -281,7 +281,7 @@ type
   protected
     function InitiateActivity: TKMUnitTask; override;
   public
-    procedure Paint; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
   //Serf - transports all wares between houses
@@ -305,7 +305,7 @@ type
     function ObjToString(const aSeparator: String = '|'): String; override;
 
     function UpdateState: Boolean; override;
-    procedure Paint; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
   //Worker class - builds everything in game
@@ -318,7 +318,7 @@ type
     function PickRandomSpot(aList: TKMPointDirList; out Loc: TKMPointDir): Boolean;
 
     function UpdateState: Boolean; override;
-    procedure Paint; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
 
@@ -333,7 +333,7 @@ type
     function ReduceFish: Boolean;
     procedure Save(SaveStream: TKMemoryStream); override;
     function UpdateState: Boolean; override;
-    procedure Paint; override;
+    procedure Paint(aTickLag: Single); override;
   end;
 
 const
@@ -568,7 +568,7 @@ end;
 
 
 { TKMUnitCitizen }
-procedure TKMUnitCitizen.Paint;
+procedure TKMUnitCitizen.Paint(aTickLag: Single);
 var
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: Single;
@@ -689,7 +689,7 @@ end;
 
 
 { TKMUnitRecruit }
-procedure TKMUnitRecruit.Paint;
+procedure TKMUnitRecruit.Paint(aTickLag: Single);
 var
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: Single;
@@ -809,7 +809,7 @@ begin
 end;
 
 
-procedure TKMUnitSerf.Paint;
+procedure TKMUnitSerf.Paint(aTickLag: Single);
 var
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: Single;
@@ -954,7 +954,7 @@ begin
 end;
 
 
-procedure TKMUnitWorker.Paint;
+procedure TKMUnitWorker.Paint(aTickLag: Single);
 var
   XPaintPos, YPaintPos: Single;
   ID: Integer;
@@ -1081,7 +1081,7 @@ end;
 
 
 //For fish the action is the number of fish in the group
-procedure TKMUnitAnimal.Paint;
+procedure TKMUnitAnimal.Paint(aTickLag: Single);
 var
   Act: TKMUnitActionType;
   XPaintPos, YPaintPos: single;
@@ -2468,7 +2468,7 @@ begin
 end;
 
 
-procedure TKMUnit.Paint;
+procedure TKMUnit.Paint(aTickLag: Single);
 begin
   //Here should be catched any cases where unit has no current action - this is a flaw in TTasks somewhere
   //Unit always meant to have some Action performed.

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -21,7 +21,7 @@ type
 
   TKMUnitArray = array of TKMUnit;
 
-  TKMUnitAction = class
+  TKMUnitAction = class abstract
   protected
     fType: TKMUnitActionType;
     fUnit: TKMUnit;
@@ -43,7 +43,7 @@ type
 
   TKMTaskResult = (trTaskContinues, trTaskDone); //There's no difference between Done and Aborted
 
-  TKMUnitTask = class
+  TKMUnitTask = class abstract
   protected
     fType: TKMUnitTaskType;
     fUnit: TKMUnit; //Unit who's performing the Task
@@ -73,7 +73,7 @@ type
   end;
 
 
-  TKMUnit = class
+  TKMUnit = class abstract
   protected //Accessible for child classes
     fUID: Integer; //unique unit ID, used for save/load to sync to
     fType: TKMUnitType;
@@ -248,7 +248,7 @@ type
   end;
 
   //Common class for all civil units
-  TKMCivilUnit = class(TKMUnit)
+  TKMCivilUnit = class abstract(TKMUnit)
   public
     function GoEat(aInn: TKMHouseInn; aUnitAlreadyInsideInn: Boolean = False): Boolean;
     function CheckCondition: Boolean;
@@ -256,7 +256,7 @@ type
   end;
 
   //This is common class for all units, who can be an owner for house (recruits and all citizen workers)
-  TKMSettledUnit = class(TKMCivilUnit)
+  TKMSettledUnit = class abstract(TKMCivilUnit)
   private
     procedure CleanHousePointer(aFreeAndNilTask: Boolean = False);
   protected

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -3,7 +3,7 @@ unit KM_Units;
 interface
 uses
   Classes, Math, SysUtils, KromUtils, Types,
-  KM_CommonClasses, KM_CommonTypes, KM_Defaults, KM_Points, KM_CommonUtils,
+  KM_CommonClasses, KM_CommonTypes, KM_Defaults, KM_Points, KM_CommonUtils, KM_UnitVisual,
   KM_Terrain, KM_ResHouses, KM_ResWares, KM_Houses, KM_HouseSchool, KM_HouseBarracks, KM_HouseInn;
 
 //Memo on directives:
@@ -103,6 +103,8 @@ type
 
     //No saved fields, used only in players UI
     fDismissInProgress: Boolean; //Mark unit as waiting for Dismiss GIC cmd, to show proper UI
+
+    fVisual: TKMUnitVisual;
 
     function GetDesiredPassability: TKMTerrainPassability;
     function GetHitPointsMax: Byte;
@@ -1149,6 +1151,8 @@ begin
 
   SetActionLockedStay(10, uaWalk); //Must be locked for this initial pause so animals don't get pushed
 
+  fVisual := TKMUnitVisual.Create(Self);
+
   // Do not add units which are trained inside house
   if not aInHouse then
     gTerrain.UnitAdd(NextPosition, Self);
@@ -1164,6 +1168,7 @@ begin
   if not IsDead then gTerrain.UnitRem(NextPosition); //Happens only when removing player from map on GameStart (network)
   FreeAndNil(fAction);
   FreeAndNil(fTask);
+  FreeAndNil(fVisual);
   SetInHouse(nil); //Free pointer
   inherited;
 end;

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -241,6 +241,7 @@ type
 
     procedure Save(SaveStream: TKMemoryStream); virtual;
     function UpdateState: Boolean; virtual;
+    procedure UpdateVisualState;
     procedure Paint(aTickLag: Single); virtual;
 
     class function GetDefaultCondition: Integer;
@@ -2087,6 +2088,11 @@ begin
   end;
 end;
 
+
+procedure TKMUnit.UpdateVisualState;
+begin
+  fVisual.UpdateState;
+end;
 
 procedure TKMUnit.VertexAdd(const aFrom, aTo: TKMPoint);
 begin

--- a/src/units/KM_UnitsCollection.pas
+++ b/src/units/KM_UnitsCollection.pas
@@ -40,7 +40,7 @@ type
     procedure Load(LoadStream: TKMemoryStream);
     procedure SyncLoad;
     procedure UpdateState(aTick: Cardinal);
-    procedure Paint(const aRect: TKMRect);
+    procedure Paint(const aRect: TKMRect; aTickLag: Single);
   end;
 
 
@@ -361,7 +361,7 @@ begin
 end;
 
 
-procedure TKMUnitsCollection.Paint(const aRect: TKMRect);
+procedure TKMUnitsCollection.Paint(const aRect: TKMRect; aTickLag: Single);
 const
   Margin = 2;
 var

--- a/src/units/KM_UnitsCollection.pas
+++ b/src/units/KM_UnitsCollection.pas
@@ -378,7 +378,7 @@ begin
           and (Units[I].Action is TKMUnitActionWalkTo)
           and TKMUnitActionWalkTo(Units[I].Action).NeedToPaint(growRect))
         or KMInRect(Units[I].PositionF, growRect)) then
-    Units[I].Paint;
+    Units[I].Paint(aTickLag);
 end;
 
 

--- a/src/units/KM_UnitsCollection.pas
+++ b/src/units/KM_UnitsCollection.pas
@@ -332,7 +332,10 @@ begin
   try
     for I := Count - 1 downto 0 do
       if not Units[I].IsDead then
-        Units[I].UpdateState
+      begin
+        Units[I].UpdateState;
+        Units[I].UpdateVisualState;
+      end
       else
         if FREE_POINTERS and (Units[I].GetPointerCount = 0) then
           fUnits.Delete(I);


### PR DESCRIPTION
Optional interpolated render for projectiles and units. Turned on with a switch in KM_Defaults.

Only position is interpolated, animations are still at the original framerate. This means it looks kind of weird like the units are sliding. Once we have full speed animations and make some tweaks it should look better.

Only really works at 1x speed, we need to rethink the way the timer works at higher speeds so we can do smooth rendering.

I want to get this batch of changes merged before I move on to the next stage (animations).