### PR TITLE
Save position of wares list's scrollbar, when looking at Resources tab of in-game fullscreen statistics

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -1409,6 +1409,7 @@ type
     property RowCount: Integer read fRowCount;
     property ItemHeight: Byte read fItemHeight write fItemHeight;
     property Header: TKMListHeader read fHeader;
+    property TopIndex: Integer read GetTopIndex write SetTopIndex;
 
     //Sort properties are just hints to render Up/Down arrows. Actual sorting is done by client
     property OnColumnClick: TIntegerEvent read GetOnColumnClick write SetOnColumnClick;

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -1409,7 +1409,6 @@ type
     property RowCount: Integer read fRowCount;
     property ItemHeight: Byte read fItemHeight write fItemHeight;
     property Header: TKMListHeader read fHeader;
-    property TopIndex: Integer read GetTopIndex write SetTopIndex;
 
     //Sort properties are just hints to render Up/Down arrows. Actual sorting is done by client
     property OnColumnClick: TIntegerEvent read GetOnColumnClick write SetOnColumnClick;

--- a/src/gui/pages_game/KM_GUIGameResultsMP.pas
+++ b/src/gui/pages_game/KM_GUIGameResultsMP.pas
@@ -1638,7 +1638,7 @@ const
   end;
 
 var
-  I,K,J,WareInGDP, SelectedItemTag, SelectedGDPItemTag: Integer;
+  I,K,J,WareInGDP, SelectedItemTag, SelectedGDPItemTag, SelectedTopIndex, SelectedGDPTopIndex: Integer;
   W: TKMWareType;
   ListRow: TKMListRow;
   ST: TKMStatType;
@@ -1651,6 +1651,8 @@ begin
   if Columnbox_WaresGDP.IsSelected then
     SelectedGDPItemTag := Columnbox_WaresGDP.SelectedItem.Tag;
 
+  SelectedTopIndex := Columnbox_Wares.TopIndex;
+  SelectedGDPTopIndex := Columnbox_WaresGDP.TopIndex;
   //Prepare columnboxes
   Columnbox_Wares.Clear;
   Columnbox_WaresGDP.Clear;
@@ -1679,6 +1681,9 @@ begin
       Break;
     end;
   end;
+
+  Columnbox_Wares.TopIndex := SelectedTopIndex;
+  Columnbox_WaresGDP.TopIndex := SelectedGDPTopIndex;
 
   //Fill in chart values
   for ST := Low(TKMStatType) to High(TKMStatType) do


### PR DESCRIPTION
https://trello.com/c/UC7vBUQb/1234-in-game-statistics-scroll-up-automatically-on-refresh