### PR TITLE
Tick rate fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,7 +61,6 @@
 *.bbm binary
 *.fnt binary
 *.fntx binary
-*.* binary
 
 
 # Force the following filetypes to have unix eols, so Windows does not break them

--- a/src/game/KM_Game.pas
+++ b/src/game/KM_Game.pas
@@ -3190,8 +3190,6 @@ begin
 
   if aGlobalTickCount mod 10 = 0 then
     fMapEditor.UpdateState;
-
-  UpdateGame;
 end;
 
 

--- a/src/game/KM_GameApp.pas
+++ b/src/game/KM_GameApp.pas
@@ -31,8 +31,6 @@ type
 
     fMainMenuInterface: TKMMainMenuInterface;
 
-    fLastTimeRender: Cardinal;
-
     fChat: TKMChat;
 
     fOnCursorUpdate: TIntegerStringEvent;
@@ -187,8 +185,6 @@ begin
 
   // Create Server Settings in the shared folder
   fServerSettings := TKMServerSettings.Create(False);
-
-  fLastTimeRender := 0;
 
   gRender := TRender.Create(aRenderControl, aScreenX, aScreenY, aVSync);
 
@@ -1226,8 +1222,6 @@ begin
   gRender.EndFrame;
   gRender.Query.QueriesSwapBuffers;
 
-  fLastTimeRender := TimeGet;
-
   if not aForPrintScreen and (gGame <> nil) then
     if Assigned(fOnCursorUpdate) then
       fOnCursorUpdate(SB_ID_OBJECT, 'Obj: ' + IntToStr(gCursor.ObjectUID));
@@ -1299,12 +1293,6 @@ begin
     if (gGame <> nil) and not gGame.IsPaused and Assigned(fOnCursorUpdate) then
         fOnCursorUpdate(SB_ID_TIME, 'Time: ' + TimeToString(gGame.MissionTime));
   end;
-
-  if (gMain <> nil) //Could be nil for Runner Util
-    and (gMain.Settings <> nil)
-    and gMain.Settings.IsNoRenderMaxTimeSet
-    and (TimeSince(fLastTimeRender) > gMain.Settings.NoRenderMaxTime) then
-    Render;
 end;
 
 

--- a/src/game/KM_GameApp.pas
+++ b/src/game/KM_GameApp.pas
@@ -154,6 +154,7 @@ type
     procedure Render(aForPrintScreen: Boolean = False);
     procedure UpdateState;
     procedure UpdateStateIdle(aFrameTime: Cardinal);
+    procedure DoGameTick;
   end;
 
 
@@ -1315,6 +1316,13 @@ begin
   if gSoundPlayer <> nil then gSoundPlayer.UpdateStateIdle;
   if fNetworking <> nil then fNetworking.UpdateStateIdle;
   if gRes <> nil then gRes.UpdateStateIdle;
+end;
+
+
+procedure TKMGameApp.DoGameTick;
+begin
+  if gGame <> nil then
+    gGame.UpdateGame;
 end;
 
 


### PR DESCRIPTION
Refactored all of the periodic tasks and TTimers into a single "main loop" in TKMMain.DoIdle. It handles:
 - Game tick
 - Render
 - UpdateState
 - UpdateStateIdle
 - Sleeping until the next deadline when there's nothing to do

Periodic tasks like game ticks and render are scheduled so they occur at a consistent interval and we don't lose time (time slip) like we were with TTimer.

This code will not attempt to "catch up" if we something takes too long and we miss the scheduled tick (it will simply skip ahead to the next future tick schedule). The existing code in TKMGame will take care of catching up lost ticks, however it should now only occur when processing takes too long and we miss a tick.

This fixes the "jumpy" movements every ~1 second when interpolated render is on, which was caused by the TTimer not firing at a consistent rate and the "catch up" logic running two ticks at the same time to compensate.