### PR TITLE
Add StatArmyPower scripting state

### DIFF
--- a/src/common/KM_Defaults.pas
+++ b/src/common/KM_Defaults.pas
@@ -1063,6 +1063,16 @@ const
 var
   ExeDir: UnicodeString;
 
+const
+  WARRIORS_POWER_RATES: array [WARRIOR_MIN..WARRIOR_MAX] of Single = (
+    1, 2.4, 5.2,    // utMilitia, utAxeFighter, utSwordsman
+    2.2, 4,         // utBowman, utArbaletman
+    2, 4,           // utPikeman, utHallebardman
+    3.3, 6,         // utHorseScout, utCavalry
+    5.3, 1.5, 1.5,  // utBarbarian, utPeasant, utSlingshot
+    5.3, 2.1        // utMetalBarbarian, utHorseman
+  );
+
 implementation
 
 initialization

--- a/src/gui/pages_game/KM_GUIGameResultsMP.pas
+++ b/src/gui/pages_game/KM_GUIGameResultsMP.pas
@@ -191,15 +191,6 @@ const
   SUBMENU_RIGHT_WIDTH = 170;
   BTN_BACK_TO_GAME_LEFT = RESULTS_X_PADDING + 330;
 
-  WARRIORS_POWER_RATES: array [WARRIOR_MIN..WARRIOR_MAX] of Single = (
-    1, 2.4, 5.2,    // utMilitia, utAxeFighter, utSwordsman
-    2.2, 4,         // utBowman, utArbaletman
-    2, 4,           // utPikeman, utHallebardman
-    3.3, 6,         // utHorseScout, utCavalry
-    5.3, 1.5, 1.5,  // utBarbarian, utPeasant, utSlingshot
-    5.3, 2.1        // utMetalBarbarian, utHorseman
-  );
-
   GDPWares: array [0..2] of TKMWareType = (wtAll, wtWarfare, wtFood);
 
 

--- a/src/hands/KM_HandStats.pas
+++ b/src/hands/KM_HandStats.pas
@@ -497,7 +497,7 @@ var
 begin
   Result := 0;
   for UT := WARRIOR_MIN to WARRIOR_MAX do
-    Result := Result + Single(GetUnitQty(UT)) * WARRIORS_POWER_RATES[UT];
+    Result := Result + GetUnitQty(UT) * WARRIORS_POWER_RATES[UT];
 end;
 
 

--- a/src/hands/KM_HandStats.pas
+++ b/src/hands/KM_HandStats.pas
@@ -110,6 +110,7 @@ type
     function GetUnitLostQty(aType: TKMUnitType): Integer;
     function GetWareBalance(aRT: TKMWareType): Integer;
     function GetArmyCount: Integer;
+    function GetArmyPower: Single;
     function GetCitizensCount: Integer;
 
     function GetCitizensTrained: Cardinal;
@@ -487,6 +488,16 @@ begin
   Result := 0;
   for UT := WARRIOR_MIN to WARRIOR_MAX do
     Inc(Result, GetUnitQty(UT));
+end;
+
+
+function TKMHandStats.GetArmyPower: Single;
+var
+  UT: TKMUnitType;
+begin
+  Result := 0;
+  for UT := WARRIOR_MIN to WARRIOR_MAX do
+    Result := Result + Single(GetUnitQty(UT)) * WARRIORS_POWER_RATES[UT];
 end;
 
 

--- a/src/scripting/KM_Scripting.pas
+++ b/src/scripting/KM_Scripting.pas
@@ -544,6 +544,7 @@ begin
 
     RegisterMethodCheck(c, 'function StatAIDefencePositionsCount(aPlayer: Byte): Integer');
     RegisterMethodCheck(c, 'function StatArmyCount(aPlayer: Byte): Integer');
+    RegisterMethodCheck(c, 'function StatArmyPower(aPlayer: Byte): Single');
     RegisterMethodCheck(c, 'function StatCitizenCount(aPlayer: Byte): Integer');
     RegisterMethodCheck(c, 'function StatHouseCount(aPlayer: Byte): Integer');
     RegisterMethodCheck(c, 'function StatHouseMultipleTypesCount(aPlayer: Byte; aTypes: TByteSet): Integer');
@@ -1225,6 +1226,7 @@ begin
 
       RegisterMethod(@TKMScriptStates.StatAIDefencePositionsCount,              'StatAIDefencePositionsCount');
       RegisterMethod(@TKMScriptStates.StatArmyCount,                            'StatArmyCount');
+      RegisterMethod(@TKMScriptStates.StatArmyPower,                            'StatArmyPower');
       RegisterMethod(@TKMScriptStates.StatCitizenCount,                         'StatCitizenCount');
       RegisterMethod(@TKMScriptStates.StatHouseCount,                           'StatHouseCount');
       RegisterMethod(@TKMScriptStates.StatHouseMultipleTypesCount,              'StatHouseMultipleTypesCount');

--- a/src/scripting/KM_ScriptingStates.pas
+++ b/src/scripting/KM_ScriptingStates.pas
@@ -178,6 +178,7 @@ type
 
     function StatAIDefencePositionsCount(aPlayer: Byte): Integer;
     function StatArmyCount(aPlayer: Byte): Integer;
+    function StatArmyPower(aPlayer: Byte): Single;
     function StatCitizenCount(aPlayer: Byte): Integer;
     function StatHouseCount(aPlayer: Byte): Integer;
     function StatHouseMultipleTypesCount(aPlayer: Byte; aTypes: TByteSet): Integer;
@@ -949,6 +950,26 @@ begin
     begin
       Result := 0;
       LogParamWarning('States.StatArmyCount', [aPlayer]);
+    end;
+  except
+    gScriptEvents.ExceptionOutsideScript := True; //Don't blame script for this exception
+    raise;
+  end;
+end;
+
+
+//* Version: Must be filled in by Rey
+//* The power factor of a player's army
+//* Result: Army power
+function TKMScriptStates.StatArmyPower(aPlayer: Byte): Single;
+begin
+  try
+    if InRange(aPlayer, 0, gHands.Count - 1) and (gHands[aPlayer].Enabled) then
+      Result := gHands[aPlayer].Stats.GetArmyPower
+    else
+    begin
+      Result := 0.0;
+      LogParamWarning('States.StatArmyPower', [aPlayer]);
     end;
   except
     gScriptEvents.ExceptionOutsideScript := True; //Don't blame script for this exception


### PR DESCRIPTION
Added the scripting state `StatArmyPower`, which returns the army power of a specified player.

This PR moves the constant `WARRIORS_POWER_RATES` from `KM_GUIGameResultsMP.pas` to `KM_Defaults.pas`, which was done to make the constant accessible to `KM_HandStats.pas`.

One change by Rey is required: The comment describing at what revision this new state is added needs to be filled out.