### PR TITLE
New zoom functionality behaviour

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10305,7 +10305,7 @@ begin
       R := fView.GetMinimapClip;
       if (R.Right - R.Left) * (R.Bottom - R.Top) > 0 then
       begin
-        if gGameSettings.NewZoomBehaviour then
+        if gGameSettings.ZoomBehaviour > 0 then
         begin
           miniLeft := AbsLeft + fLeftOffset + Round(R.Left * fPaintWidth / fMinimap.MapX) - 1;
           miniTop := AbsTop + fTopOffset + Round(R.Top * fPaintHeight / fMinimap.MapY) - 1;

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10269,7 +10269,7 @@ const
 var
   I, K: Integer;
   R: TKMRect;
-  B: TBits;
+  S: TKMDirection4Set;
   T, T1, T2: TKMPoint;
   minimapGame: TKMMiniMapGame;
   miniLeft, miniTop, miniRight, miniBottom: SmallInt;
@@ -10312,14 +10312,14 @@ begin
           miniRight := AbsLeft + fLeftOffset + Round((R.Right - 1)*fPaintWidth / fMinimap.MapX);
           miniBottom := AbsTop + fTopOffset  + Round((R.Bottom - 1)*fPaintHeight / fMinimap.MapY) - 1;
 
-          B := fView.GetMinimapClipLines;
-          if B[Integer(TKMDirection4.drW)] then
+          S := fView.GetMinimapClipLines;
+          if drW in S then
             TKMRenderUI.WriteLine(miniLeft, miniBottom+1, miniLeft, miniTop, $FFFFFFFF);
-          if B[Integer(TKMDirection4.drN)] then
+          if drN in S then
             TKMRenderUI.WriteLine(miniLeft-1, miniTop, miniRight, miniTop, $FFFFFFFF);
-          if B[Integer(TKMDirection4.drE)] then
+          if drE in S then
             TKMRenderUI.WriteLine(miniRight, miniBottom+1, miniRight, miniTop, $FFFFFFFF);
-          if B[Integer(TKMDirection4.drS)] then
+          if drS in S then
             TKMRenderUI.WriteLine(miniLeft-1, miniBottom, miniRight, miniBottom, $FFFFFFFF);
         end
         else

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10305,7 +10305,7 @@ begin
       R := fView.GetMinimapClip;
       if (R.Right - R.Left) * (R.Bottom - R.Top) > 0 then
       begin
-        if gGameSettings.ZoomBehaviour > 0 then
+        if gGameSettings.ZoomBehaviour <> zbRestricted then
         begin
           miniLeft := AbsLeft + fLeftOffset + Round((R.Left - 1)*fPaintWidth / fMinimap.MapX) + 1;
           miniTop := AbsTop + fTopOffset  + Round((R.Top - 1)*fPaintHeight / fMinimap.MapY);

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10307,10 +10307,10 @@ begin
       begin
         if gGameSettings.ZoomBehaviour > 0 then
         begin
-          miniLeft := AbsLeft + fLeftOffset + Round(R.Left * fPaintWidth / fMinimap.MapX) - 1;
-          miniTop := AbsTop + fTopOffset + Round(R.Top * fPaintHeight / fMinimap.MapY) - 1;
-          miniRight := AbsLeft + fLeftOffset + Round(R.Right * fPaintWidth / fMinimap.MapX) - 1;
-          miniBottom := AbsTop + fTopOffset + Round(R.Bottom * fPaintHeight / fMinimap.MapY) - 1;
+          miniLeft := AbsLeft + fLeftOffset + Round((R.Left - 1)*fPaintWidth / fMinimap.MapX) + 1;
+          miniTop := AbsTop + fTopOffset  + Round((R.Top - 1)*fPaintHeight / fMinimap.MapY);
+          miniRight := AbsLeft + fLeftOffset + Round((R.Right - 1)*fPaintWidth / fMinimap.MapX);
+          miniBottom := AbsTop + fTopOffset  + Round((R.Bottom - 1)*fPaintHeight / fMinimap.MapY) - 1;
 
           B := fView.GetMinimapClipLines;
           if B[0] then //Left

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10313,13 +10313,13 @@ begin
           miniBottom := AbsTop + fTopOffset  + Round((R.Bottom - 1)*fPaintHeight / fMinimap.MapY) - 1;
 
           B := fView.GetMinimapClipLines;
-          if B[0] then //Left
+          if B[Integer(TKMDirection4.drW)] then
             TKMRenderUI.WriteLine(miniLeft, miniBottom+1, miniLeft, miniTop, $FFFFFFFF);
-          if B[1] then //Right
+          if B[Integer(TKMDirection4.drE)] then
             TKMRenderUI.WriteLine(miniRight, miniBottom+1, miniRight, miniTop, $FFFFFFFF);
-          if B[2] then //Top
+          if B[Integer(TKMDirection4.drN)] then
             TKMRenderUI.WriteLine(miniLeft-1, miniTop, miniRight, miniTop, $FFFFFFFF);
-          if B[3] then //Bottom
+          if B[Integer(TKMDirection4.drS)] then
             TKMRenderUI.WriteLine(miniLeft-1, miniBottom, miniRight, miniBottom, $FFFFFFFF);
         end
         else

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -2041,7 +2041,8 @@ uses
   KM_MinimapGame,
   KM_Resource, KM_ResSprites, KM_ResSound, KM_ResTexts,
   KM_Render, KM_RenderTypes,
-  KM_Sound, KM_CommonUtils, KM_UtilsExt;
+  KM_Sound, KM_CommonUtils, KM_UtilsExt,
+  KM_GameSettings;
 
 
 const
@@ -10268,8 +10269,10 @@ const
 var
   I, K: Integer;
   R: TKMRect;
+  B: TBits;
   T, T1, T2: TKMPoint;
   minimapGame: TKMMiniMapGame;
+  miniLeft, miniTop, miniRight, miniBottom: SmallInt;
 begin
   inherited;
 
@@ -10301,10 +10304,32 @@ begin
     begin
       R := fView.GetMinimapClip;
       if (R.Right - R.Left) * (R.Bottom - R.Top) > 0 then
-        TKMRenderUI.WriteOutline(AbsLeft + fLeftOffset + Round((R.Left - 1)*fPaintWidth / fMinimap.MapX),
-                                 AbsTop  + fTopOffset  + Round((R.Top - 1)*fPaintHeight / fMinimap.MapY),
-                                 Round((R.Right - R.Left)*fPaintWidth / fMinimap.MapX),
-                                 Round((R.Bottom - R.Top + 1)*fPaintHeight / fMinimap.MapY), 1, $FFFFFFFF);
+      begin
+        if gGameSettings.NewZoomBehaviour then
+        begin
+          miniLeft := AbsLeft + fLeftOffset + Round(R.Left * fPaintWidth / fMinimap.MapX) - 1;
+          miniTop := AbsTop + fTopOffset + Round(R.Top * fPaintHeight / fMinimap.MapY) - 1;
+          miniRight := AbsLeft + fLeftOffset + Round(R.Right * fPaintWidth / fMinimap.MapX) - 1;
+          miniBottom := AbsTop + fTopOffset + Round(R.Bottom * fPaintHeight / fMinimap.MapY) - 1;
+
+          B := fView.GetMinimapClipLines;
+          if B[0] then //Left
+            TKMRenderUI.WriteLine(miniLeft, miniBottom+1, miniLeft, miniTop, $FFFFFFFF);
+          if B[1] then //Right
+            TKMRenderUI.WriteLine(miniRight, miniBottom+1, miniRight, miniTop, $FFFFFFFF);
+          if B[2] then //Top
+            TKMRenderUI.WriteLine(miniLeft-1, miniTop, miniRight, miniTop, $FFFFFFFF);
+          if B[3] then //Bottom
+            TKMRenderUI.WriteLine(miniLeft-1, miniBottom, miniRight, miniBottom, $FFFFFFFF);
+        end
+        else
+        begin
+          TKMRenderUI.WriteOutline(AbsLeft + fLeftOffset + Round((R.Left - 1)*fPaintWidth / fMinimap.MapX),
+                                   AbsTop  + fTopOffset  + Round((R.Top - 1)*fPaintHeight / fMinimap.MapY),
+                                   Round((R.Right - R.Left)*fPaintWidth / fMinimap.MapX),
+                                   Round((R.Bottom - R.Top + 1)*fPaintHeight / fMinimap.MapY), 1, $FFFFFFFF);
+        end;
+      end;
     end;
   end;
 

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10315,10 +10315,10 @@ begin
           B := fView.GetMinimapClipLines;
           if B[Integer(TKMDirection4.drW)] then
             TKMRenderUI.WriteLine(miniLeft, miniBottom+1, miniLeft, miniTop, $FFFFFFFF);
-          if B[Integer(TKMDirection4.drE)] then
-            TKMRenderUI.WriteLine(miniRight, miniBottom+1, miniRight, miniTop, $FFFFFFFF);
           if B[Integer(TKMDirection4.drN)] then
             TKMRenderUI.WriteLine(miniLeft-1, miniTop, miniRight, miniTop, $FFFFFFFF);
+          if B[Integer(TKMDirection4.drE)] then
+            TKMRenderUI.WriteLine(miniRight, miniBottom+1, miniRight, miniTop, $FFFFFFFF);
           if B[Integer(TKMDirection4.drS)] then
             TKMRenderUI.WriteLine(miniLeft-1, miniBottom, miniRight, miniBottom, $FFFFFFFF);
         end

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -10327,7 +10327,7 @@ begin
           TKMRenderUI.WriteOutline(AbsLeft + fLeftOffset + Round((R.Left - 1)*fPaintWidth / fMinimap.MapX),
                                    AbsTop  + fTopOffset  + Round((R.Top - 1)*fPaintHeight / fMinimap.MapY),
                                    Round((R.Right - R.Left)*fPaintWidth / fMinimap.MapX),
-                                   Round((R.Bottom - R.Top + 1)*fPaintHeight / fMinimap.MapY), 1, $FFFFFFFF);
+                                   Round((R.Bottom - R.Top)*fPaintHeight / fMinimap.MapY), 1, $FFFFFFFF);
         end;
       end;
     end;

--- a/src/KM_GameApp.pas
+++ b/src/KM_GameApp.pas
@@ -1297,8 +1297,7 @@ begin
     Resize(Round(saveSizeMax * mapSizeX / mapSizeMax), Round(saveSizeMax * mapSizeY / mapSizeMax));
 
     // Center the map and zoom out to perfectly encapsulate it
-    gGame.ActiveInterface.Viewport.Zoom := max(gGame.ActiveInterface.Viewport.ViewportClip.X/(CELL_SIZE_PX * (mapSizeX - 1)),
-                                                gGame.ActiveInterface.Viewport.ViewportClip.Y/(CELL_SIZE_PX * (mapSizeY + gGame.ActiveInterface.Viewport.TopPad - 1)));
+    gGame.ActiveInterface.Viewport.Zoom := gGame.ActiveInterface.Viewport.ViewportClip.X/(CELL_SIZE_PX * (mapSizeX - 1));
     gGame.ActiveInterface.Viewport.Position := TKMPointF.New((mapSizeX - 1)/2, (mapSizeY - 1 - gGame.ActiveInterface.Viewport.TopPad)/2);
 
     // Render once is enough, since we render to an off-screen buffer (FBO)

--- a/src/KM_GameApp.pas
+++ b/src/KM_GameApp.pas
@@ -1296,8 +1296,10 @@ begin
 
     Resize(Round(saveSizeMax * mapSizeX / mapSizeMax), Round(saveSizeMax * mapSizeY / mapSizeMax));
 
-    // Zoom out as max as possible
-    gGame.ActiveInterface.Viewport.Zoom := 0.01;
+    // Center the map and zoom out to perfectly encapsulate it
+    gGame.ActiveInterface.Viewport.Zoom := max(gGame.ActiveInterface.Viewport.ViewportClip.X/(CELL_SIZE_PX * (mapSizeX - 1)),
+                                                gGame.ActiveInterface.Viewport.ViewportClip.Y/(CELL_SIZE_PX * (mapSizeY + gGame.ActiveInterface.Viewport.TopPad - 1)));
+    gGame.ActiveInterface.Viewport.Position := TKMPointF.New((mapSizeX - 1)/2, (mapSizeY - 1 - gGame.ActiveInterface.Viewport.TopPad)/2);
 
     // Render once is enough, since we render to an off-screen buffer (FBO)
     Render(True);

--- a/src/common/KM_CommonTypes.pas
+++ b/src/common/KM_CommonTypes.pas
@@ -99,6 +99,8 @@ type
 
   TKMGameRevision = Word; // Word looks enough for now...
 
+  TKMZoomBehaviour = (zbRestricted, zbFull, zbLoose);
+
   TKMColor3f = record
     R,G,B: Single;
     function ToCardinal: Cardinal;

--- a/src/common/KM_Points.pas
+++ b/src/common/KM_Points.pas
@@ -7,6 +7,8 @@ type
   TKMDirection = (dirNA, dirN, dirNE, dirE, dirSE, dirS, dirSW, dirW, dirNW);
   TKMDirection4 = (drNA, drN, drE, drS, drW);
 
+  TKMDirection4Set = set of TKMDirection4;
+
 type
   //Records must be packed so they are stored identically in MP saves (padding bytes are unknown values)
   TKMPointF = record

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -102,14 +102,16 @@ var
 begin
   fZoom := EnsureRange(aZoom, 0.01, 8);
 
-  {
-  sizeY := fMapY + TopPad;
-  //Limit the zoom to within the map boundaries
-  if fViewportClip.X/ZoomedCellSizePX > fMapX then
-    fZoom := fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)); // -1 to not show last column under FOW (out of the map)
-  if fViewportClip.Y/ZoomedCellSizePX > sizeY then
-    fZoom := fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1)); // -1 to not show last row under FOW (out of the map)
-  }
+  if not gGameSettings.NewZoomBehaviour then
+  begin
+    sizeY := fMapY + TopPad;
+
+    //Limit the zoom to within the map boundaries
+    if fViewportClip.X/ZoomedCellSizePX > fMapX then
+      fZoom := fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)); // -1 to not show last column under FOW (out of the map)
+    if fViewportClip.Y/ZoomedCellSizePX > sizeY then
+      fZoom := fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1)); // -1 to not show last row under FOW (out of the map)
+  end;
 
   SetPosition(fPosition); //To ensure it sets the limits smoothly
 end;
@@ -170,28 +172,32 @@ procedure TKMViewport.SetPosition(const Value: TKMPointF);
 var
   tilesX, tilesY: Single;
 begin
-  {
-  tilesX := fViewportClip.X/2/ZoomedCellSizePX;
-  tilesY := fViewportClip.Y/2/ZoomedCellSizePX;
 
-  // Set position as a pointF in the map coordinates, but also with possible TopPad at the top
-  fPosition.X := EnsureRange(Value.X,
-                             tilesX,               // Min visible map coordinate is 0
-                             fMapX - 1 - tilesX ); // Max visible map coordinate is fMapX - 1
-  //Top row should be visible
-  fPosition.Y := EnsureRange(Value.Y,
-                             tilesY - TopPad,     // Min visible map coordinate is -TopPad
-                             fMapY - 1 - tilesY); // Max visible map coordinate is fMapY - 1
-  }
+  if gGameSettings.NewZoomBehaviour then
+  begin
+    // Set position as a pointF in the map coordinates, but also with possible TopPad at the top
+    fPosition.X := EnsureRange(Value.X,
+                               0,               // Min visible map coordinate is 0
+                               fMapX - 1); // Max visible map coordinate is fMapX - 1
+    //Top row should be visible
+    fPosition.Y := EnsureRange(Value.Y,
+                               - TopPad,     // Min visible map coordinate is -TopPad
+                               fMapY - 1); // Max visible map coordinate is fMapY - 1
+  end
+  else
+  begin
+    tilesX := fViewportClip.X/2/ZoomedCellSizePX;
+    tilesY := fViewportClip.Y/2/ZoomedCellSizePX;
 
-  // Set position as a pointF in the map coordinates, but also with possible TopPad at the top
-  fPosition.X := EnsureRange(Value.X,
-                             0,               // Min visible map coordinate is 0
-                             fMapX - 1); // Max visible map coordinate is fMapX - 1
-  //Top row should be visible
-  fPosition.Y := EnsureRange(Value.Y,
-                             - TopPad,     // Min visible map coordinate is -TopPad
-                             fMapY - 1); // Max visible map coordinate is fMapY - 1
+    // Set position as a pointF in the map coordinates, but also with possible TopPad at the top
+    fPosition.X := EnsureRange(Value.X,
+                               tilesX,               // Min visible map coordinate is 0
+                               fMapX - 1 - tilesX ); // Max visible map coordinate is fMapX - 1
+    //Top row should be visible
+    fPosition.Y := EnsureRange(Value.Y,
+                               tilesY - TopPad,     // Min visible map coordinate is -TopPad
+                               fMapY - 1 - tilesY); // Max visible map coordinate is fMapY - 1
+  end;
 
   if Assigned(fOnPositionSet) then
     fOnPositionSet(fPosition);

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -267,7 +267,7 @@ begin
   Result.Left   := Max(Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1, 1);
   Result.Right  := Min(Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1, fMapX);
   Result.Top    := Max(Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 2, 1);
-  Result.Bottom := Min(Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX), fMapY - 1);
+  Result.Bottom := Min(Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX), fMapY);
 end;
 
 
@@ -280,7 +280,7 @@ begin
   Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;     //Left
   Result.Bits[1] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX; //Right
   Result.Bits[2] := Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1;     //Top
-  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY - 1;     //Bottom
+  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY;     //Bottom
 end;
 
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -277,12 +277,12 @@ end;
 function TKMViewport.GetMinimapClipLines: TBits;
 begin
   Result := Tbits.Create;
-  Result.Size := 4;
+  Result.Size := 5;
 
-  Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1; //Left
-  Result.Bits[1] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX; //Right
-  Result.Bits[2] := Round(fPosition.Y + TopPad - fViewportClip.Y/2/ZoomedCellSizePX) + 1 >= 1; //Top
-  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1 <= fMapY; //Bottom
+  Result.Bits[Integer(TKMDirection4.drW)] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;
+  Result.Bits[Integer(TKMDirection4.drE)] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX;
+  Result.Bits[Integer(TKMDirection4.drN)] := Round(fPosition.Y + TopPad - fViewportClip.Y/2/ZoomedCellSizePX) + 1 >= 1;
+  Result.Bits[Integer(TKMDirection4.drS)] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1 <= fMapY;
 end;
 
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -280,8 +280,8 @@ begin
   Result.Size := 5;
 
   Result.Bits[Integer(TKMDirection4.drW)] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;
-  Result.Bits[Integer(TKMDirection4.drE)] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX;
   Result.Bits[Integer(TKMDirection4.drN)] := Round(fPosition.Y + TopPad - fViewportClip.Y/2/ZoomedCellSizePX) + 1 >= 1;
+  Result.Bits[Integer(TKMDirection4.drE)] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX;
   Result.Bits[Integer(TKMDirection4.drS)] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1 <= fMapY;
 end;
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -3,7 +3,7 @@ unit KM_Viewport;
 interface
 uses
   {$IFDEF MSWINDOWS} Windows, {$ENDIF}
-  KM_CommonClasses, KM_CommonTypes, KM_Points, Classes;
+  KM_CommonClasses, KM_CommonTypes, KM_Points;
 
 
 type
@@ -50,7 +50,7 @@ type
     procedure ResizeMap(aMapX, aMapY: Word; aTopHill: Single);
     function GetClip: TKMRect; //returns visible area dimensions in map space
     function GetMinimapClip: TKMRect;
-    function GetMinimapClipLines: TBits;
+    function GetMinimapClipLines: TKMDirection4Set;
     procedure ReleaseScrollKeys;
     procedure GameSpeedChanged(aFromSpeed, aToSpeed: Single);
     function MapToScreen(const aMapLoc: TKMPointF): TKMPoint;
@@ -274,15 +274,16 @@ end;
 
 
 //Acquires a bit array that holds what camera lines to draw on the minimap
-function TKMViewport.GetMinimapClipLines: TBits;
+function TKMViewport.GetMinimapClipLines: TKMDirection4Set;
 begin
-  Result := Tbits.Create;
-  Result.Size := 5;
-
-  Result.Bits[Integer(TKMDirection4.drW)] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;
-  Result.Bits[Integer(TKMDirection4.drN)] := Round(fPosition.Y + TopPad - fViewportClip.Y/2/ZoomedCellSizePX) + 1 >= 1;
-  Result.Bits[Integer(TKMDirection4.drE)] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX;
-  Result.Bits[Integer(TKMDirection4.drS)] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1 <= fMapY;
+  if Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1 then
+    Include(Result, drW);
+  if Round(fPosition.Y + TopPad - fViewportClip.Y/2/ZoomedCellSizePX) + 1 >= 1 then
+    Include(Result, drN);
+  if Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX then
+    Include(Result, drE);
+  if Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1 <= fMapY then
+    Include(Result, drS);
 end;
 
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -242,7 +242,7 @@ begin
 end;
 
 
-//Acquires an bit array that tells what lines to render on the minimap
+//Acquires a bit array that holds what camera lines to draw on the minimap
 function TKMViewport.GetMinimapClipLines: TBits;
 begin
   Result := Tbits.Create;

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -100,6 +100,8 @@ end;
 procedure TKMViewport.SetZoom(aZoom: Single);
 var
   sizeY, mapZoom: Single;
+const
+  BORDER_MARGIN = 1.1;
 begin
   fZoom := EnsureRange(aZoom, 0.01, 8);
 
@@ -107,21 +109,21 @@ begin
 
   case (gGameSettings.ZoomBehaviour) of
     //Limit the zoom to within the map boundaries
-    0 :
+    zbRestricted :
       begin
         mapZoom := max(fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)), fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1))); // -1 to not show last column/row under FOW (out of the map)
         fZoom := max(fZoom, mapZoom);
       end;
     //Prevents the zoom from crossing both map boundaries
-    1 :
+    zbFull :
       begin
         mapZoom := min(fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)), fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1)));
         fZoom := max(fZoom, mapZoom);
       end;
     //Limit the zoom to 1.1x the map width or height
-    2 :
+    zbLoose :
       begin
-        mapZoom := min(fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)), fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1))) / 1.1;
+        mapZoom := min(fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)), fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1))) / BORDER_MARGIN;
         mapZoom := min(mapZoom, 1);
         fZoom := max(fZoom, mapZoom);
       end;
@@ -188,7 +190,7 @@ var
 begin
 
   case (gGameSettings.ZoomBehaviour) of
-    0 :
+    zbRestricted :
       begin
         tilesX := fViewportClip.X/2/ZoomedCellSizePX;
         tilesY := fViewportClip.Y/2/ZoomedCellSizePX;
@@ -202,7 +204,7 @@ begin
                                    tilesY - TopPad,     // Min visible map coordinate is -TopPad
                                    fMapY - 1 - tilesY); // Max visible map coordinate is fMapY - 1
       end;
-    1 :
+    zbFull :
       begin
         tilesX := min(fViewportClip.X/2/ZoomedCellSizePX, (fMapX - 1) / 2);
         tilesY := min(fViewportClip.Y/2/ZoomedCellSizePX, (fMapY - 1 + TopPad) / 2);
@@ -216,7 +218,7 @@ begin
                                    tilesY - TopPad,     // Min visible map coordinate is -TopPad
                                    fMapY - 1 - tilesY); // Max visible map coordinate is fMapY - 1
       end;
-    2 :
+    zbLoose :
       begin
         // Set position as a pointF in the map coordinates, but also with possible TopPad at the top
         fPosition.X := EnsureRange(Value.X,

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -281,7 +281,7 @@ begin
 
   Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;     //Left
   Result.Bits[1] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX; //Right
-  Result.Bits[2] := Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1;     //Top
+  Result.Bits[2] := Round(fPosition.Y + fTopHill - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1;     //Top
   Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY;     //Bottom
 end;
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -3,7 +3,7 @@ unit KM_Viewport;
 interface
 uses
   {$IFDEF MSWINDOWS} Windows, {$ENDIF}
-  KM_CommonClasses, KM_CommonTypes, KM_Points;
+  KM_CommonClasses, KM_CommonTypes, KM_Points, Classes;
 
 
 type
@@ -50,6 +50,7 @@ type
     procedure ResizeMap(aMapX, aMapY: Word; aTopHill: Single);
     function GetClip: TKMRect; //returns visible area dimensions in map space
     function GetMinimapClip: TKMRect;
+    function GetMinimapClipLines: TBits;
     procedure ReleaseScrollKeys;
     procedure GameSpeedChanged(aFromSpeed, aToSpeed: Single);
     function MapToScreen(const aMapLoc: TKMPointF): TKMPoint;
@@ -237,7 +238,20 @@ begin
   Result.Left   := Max(Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1, 1);
   Result.Right  := Min(Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1, fMapX);
   Result.Top    := Max(Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 2, 1);
-  Result.Bottom := Min(Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX), fMapY);
+  Result.Bottom := Min(Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX), fMapY - 1);
+end;
+
+
+//Acquires an bit array that tells what lines to render on the minimap
+function TKMViewport.GetMinimapClipLines: TBits;
+begin
+  Result := Tbits.Create;
+  Result.Size := 4;
+
+  Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;     //Left
+  Result.Bits[1] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX; //Right
+  Result.Bits[2] := Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1;     //Top
+  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY - 1;     //Bottom
 end;
 
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -279,10 +279,10 @@ begin
   Result := Tbits.Create;
   Result.Size := 4;
 
-  Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1;     //Left
+  Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1; //Left
   Result.Bits[1] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX; //Right
-  Result.Bits[2] := Round(fPosition.Y + fTopHill - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1;     //Top
-  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY;     //Bottom
+  Result.Bits[2] := Round(fPosition.Y + fTopHill - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1; //Top
+  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY; //Bottom
 end;
 
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -268,8 +268,8 @@ function TKMViewport.GetMinimapClip: TKMRect;
 begin
   Result.Left   := Max(Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1, 1);
   Result.Right  := Min(Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1, fMapX);
-  Result.Top    := Max(Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 2, 1);
-  Result.Bottom := Min(Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX), fMapY);
+  Result.Top    := Max(Round(fPosition.Y - fViewportClip.Y/2/ZoomedCellSizePX) + 1, 1);
+  Result.Bottom := Min(Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1, fMapY);
 end;
 
 
@@ -281,8 +281,8 @@ begin
 
   Result.Bits[0] := Round(fPosition.X - (fViewportClip.X/2 - fViewRect.Left + ToolbarWidth)/ZoomedCellSizePX) + 1 >= 1; //Left
   Result.Bits[1] := Round(fPosition.X + (fViewportClip.X/2 + fViewRect.Left - ToolbarWidth)/ZoomedCellSizePX) + 1 <= fMapX; //Right
-  Result.Bits[2] := Round(fPosition.Y + fTopHill - fViewportClip.Y/2/ZoomedCellSizePX) + 2 >= 1; //Top
-  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) <= fMapY; //Bottom
+  Result.Bits[2] := Round(fPosition.Y + TopPad - fViewportClip.Y/2/ZoomedCellSizePX) + 1 >= 1; //Top
+  Result.Bits[3] := Round(fPosition.Y + fViewportClip.Y/2/ZoomedCellSizePX) + 1 <= fMapY; //Bottom
 end;
 
 

--- a/src/gui/KM_Viewport.pas
+++ b/src/gui/KM_Viewport.pas
@@ -101,12 +101,15 @@ var
   sizeY: Single;
 begin
   fZoom := EnsureRange(aZoom, 0.01, 8);
+
+  {
   sizeY := fMapY + TopPad;
   //Limit the zoom to within the map boundaries
   if fViewportClip.X/ZoomedCellSizePX > fMapX then
     fZoom := fViewportClip.X/(CELL_SIZE_PX * (fMapX - 1)); // -1 to not show last column under FOW (out of the map)
   if fViewportClip.Y/ZoomedCellSizePX > sizeY then
     fZoom := fViewportClip.Y/(CELL_SIZE_PX * (sizeY - 1)); // -1 to not show last row under FOW (out of the map)
+  }
 
   SetPosition(fPosition); //To ensure it sets the limits smoothly
 end;
@@ -167,6 +170,7 @@ procedure TKMViewport.SetPosition(const Value: TKMPointF);
 var
   tilesX, tilesY: Single;
 begin
+  {
   tilesX := fViewportClip.X/2/ZoomedCellSizePX;
   tilesY := fViewportClip.Y/2/ZoomedCellSizePX;
 
@@ -178,6 +182,16 @@ begin
   fPosition.Y := EnsureRange(Value.Y,
                              tilesY - TopPad,     // Min visible map coordinate is -TopPad
                              fMapY - 1 - tilesY); // Max visible map coordinate is fMapY - 1
+  }
+
+  // Set position as a pointF in the map coordinates, but also with possible TopPad at the top
+  fPosition.X := EnsureRange(Value.X,
+                             0,               // Min visible map coordinate is 0
+                             fMapX - 1); // Max visible map coordinate is fMapX - 1
+  //Top row should be visible
+  fPosition.Y := EnsureRange(Value.Y,
+                             - TopPad,     // Min visible map coordinate is -TopPad
+                             fMapY - 1); // Max visible map coordinate is fMapY - 1
 
   if Assigned(fOnPositionSet) then
     fOnPositionSet(fPosition);

--- a/src/settings/KM_GameSettings.pas
+++ b/src/settings/KM_GameSettings.pas
@@ -58,7 +58,7 @@ type
     fGameTweaks_AllowSnowHouses: Boolean;
     fGameTweaks_InterpolatedRender: Boolean;
     fGameTweaks_InterpolatedAnimations: Boolean;
-    fGameTweaks_ZoomBehaviour: Byte;
+    fGameTweaks_ZoomBehaviour: TKMZoomBehaviour;
 
     //Campaign
     fCampaignLastDifficulty: TKMMissionDifficulty;
@@ -151,7 +151,7 @@ type
     procedure SetAllowSnowHouses(aValue: Boolean);
     procedure SetInterpolatedRender(aValue: Boolean);
     procedure SetInterpolatedAnimations(const aValue: Boolean);
-    procedure SetZoomBehaviour(const aValue: Byte);
+    procedure SetZoomBehaviour(const aValue: TKMZoomBehaviour);
 
     //Campaign
     procedure SetCampaignLastDifficulty(aValue: TKMMissionDifficulty);
@@ -259,7 +259,7 @@ type
     property AllowSnowHouses: Boolean read fGameTweaks_AllowSnowHouses write SetAllowSnowHouses;
     property InterpolatedRender: Boolean read fGameTweaks_InterpolatedRender write SetInterpolatedRender;
     property InterpolatedAnimations: Boolean read fGameTweaks_InterpolatedAnimations write SetInterpolatedAnimations;
-    property ZoomBehaviour: Byte read fGameTweaks_ZoomBehaviour write SetZoomBehaviour;
+    property ZoomBehaviour: TKMZoomBehaviour read fGameTweaks_ZoomBehaviour write SetZoomBehaviour;
 
     //Campaign
     property CampaignLastDifficulty: TKMMissionDifficulty read fCampaignLastDifficulty write SetCampaignLastDifficulty;
@@ -494,7 +494,7 @@ begin
     nGameTweaks := nGameCommon.AddOrFindChild('Tweaks');
       AllowSnowHouses     := nGameTweaks.Attributes['AllowSnowHouses'].AsBoolean(True);     // With restriction by ALLOW_SNOW_HOUSES
       InterpolatedRender  := nGameTweaks.Attributes['InterpolatedRender'].AsBoolean(False); // With restriction by ALLOW_INTERPOLATED_RENDER
-      ZoomBehaviour    := nGameTweaks.Attributes['ZoomBehaviour'].AsInteger(1);
+      ZoomBehaviour    := TKMZoomBehaviour(nGameTweaks.Attributes['ZoomBehaviour'].AsInteger(1));
 
   // Campaign
   nCampaign := nGameSettings.AddOrFindChild('Campaign');
@@ -673,7 +673,7 @@ begin
     nGameTweaks := nGameCommon.AddOrFindChild('Tweaks');
       nGameTweaks.Attributes['AllowSnowHouses']     := fGameTweaks_AllowSnowHouses;
       nGameTweaks.Attributes['InterpolatedRender']  := fGameTweaks_InterpolatedRender;
-      nGameTweaks.Attributes['ZoomBehaviour']    := fGameTweaks_ZoomBehaviour;
+      nGameTweaks.Attributes['ZoomBehaviour']    := Integer(fGameTweaks_ZoomBehaviour);
 
   // Campaign
   nCampaign := nGameSettings.AddOrFindChild('Campaign');
@@ -1055,7 +1055,7 @@ begin
   Changed;
 end;
 
-procedure TKMGameSettings.SetZoomBehaviour(const aValue: Byte);
+procedure TKMGameSettings.SetZoomBehaviour(const aValue: TKMZoomBehaviour);
 begin
   fGameTweaks_ZoomBehaviour := aValue;
   Changed;

--- a/src/settings/KM_GameSettings.pas
+++ b/src/settings/KM_GameSettings.pas
@@ -58,7 +58,7 @@ type
     fGameTweaks_AllowSnowHouses: Boolean;
     fGameTweaks_InterpolatedRender: Boolean;
     fGameTweaks_InterpolatedAnimations: Boolean;
-    fGameTweaks_NewZoomBehaviour: Boolean;
+    fGameTweaks_ZoomBehaviour: Byte;
 
     //Campaign
     fCampaignLastDifficulty: TKMMissionDifficulty;
@@ -151,7 +151,7 @@ type
     procedure SetAllowSnowHouses(aValue: Boolean);
     procedure SetInterpolatedRender(aValue: Boolean);
     procedure SetInterpolatedAnimations(const aValue: Boolean);
-    procedure SetNewZoomBehaviour(const aValue: Boolean);
+    procedure SetZoomBehaviour(const aValue: Byte);
 
     //Campaign
     procedure SetCampaignLastDifficulty(aValue: TKMMissionDifficulty);
@@ -259,7 +259,7 @@ type
     property AllowSnowHouses: Boolean read fGameTweaks_AllowSnowHouses write SetAllowSnowHouses;
     property InterpolatedRender: Boolean read fGameTweaks_InterpolatedRender write SetInterpolatedRender;
     property InterpolatedAnimations: Boolean read fGameTweaks_InterpolatedAnimations write SetInterpolatedAnimations;
-    property NewZoomBehaviour: Boolean read fGameTweaks_NewZoomBehaviour write SetNewZoomBehaviour;
+    property ZoomBehaviour: Byte read fGameTweaks_ZoomBehaviour write SetZoomBehaviour;
 
     //Campaign
     property CampaignLastDifficulty: TKMMissionDifficulty read fCampaignLastDifficulty write SetCampaignLastDifficulty;
@@ -494,7 +494,7 @@ begin
     nGameTweaks := nGameCommon.AddOrFindChild('Tweaks');
       AllowSnowHouses     := nGameTweaks.Attributes['AllowSnowHouses'].AsBoolean(True);     // With restriction by ALLOW_SNOW_HOUSES
       InterpolatedRender  := nGameTweaks.Attributes['InterpolatedRender'].AsBoolean(False); // With restriction by ALLOW_INTERPOLATED_RENDER
-      NewZoomBehaviour    := nGameTweaks.Attributes['NewZoomBehaviour'].AsBoolean(True);
+      ZoomBehaviour    := nGameTweaks.Attributes['ZoomBehaviour'].AsInteger(1);
 
   // Campaign
   nCampaign := nGameSettings.AddOrFindChild('Campaign');
@@ -673,7 +673,7 @@ begin
     nGameTweaks := nGameCommon.AddOrFindChild('Tweaks');
       nGameTweaks.Attributes['AllowSnowHouses']     := fGameTweaks_AllowSnowHouses;
       nGameTweaks.Attributes['InterpolatedRender']  := fGameTweaks_InterpolatedRender;
-      nGameTweaks.Attributes['NewZoomBehaviour']    := fGameTweaks_NewZoomBehaviour;
+      nGameTweaks.Attributes['ZoomBehaviour']    := fGameTweaks_ZoomBehaviour;
 
   // Campaign
   nCampaign := nGameSettings.AddOrFindChild('Campaign');
@@ -1055,9 +1055,9 @@ begin
   Changed;
 end;
 
-procedure TKMGameSettings.SetNewZoomBehaviour(const aValue: Boolean);
+procedure TKMGameSettings.SetZoomBehaviour(const aValue: Byte);
 begin
-  fGameTweaks_NewZoomBehaviour := aValue;
+  fGameTweaks_ZoomBehaviour := aValue;
   Changed;
 end;
 

--- a/src/settings/KM_GameSettings.pas
+++ b/src/settings/KM_GameSettings.pas
@@ -58,6 +58,7 @@ type
     fGameTweaks_AllowSnowHouses: Boolean;
     fGameTweaks_InterpolatedRender: Boolean;
     fGameTweaks_InterpolatedAnimations: Boolean;
+    fGameTweaks_NewZoomBehaviour: Boolean;
 
     //Campaign
     fCampaignLastDifficulty: TKMMissionDifficulty;
@@ -149,7 +150,8 @@ type
     //GameTweaks
     procedure SetAllowSnowHouses(aValue: Boolean);
     procedure SetInterpolatedRender(aValue: Boolean);
-    procedure SetInterpolatedAnimations(const Value: Boolean);
+    procedure SetInterpolatedAnimations(const aValue: Boolean);
+    procedure SetNewZoomBehaviour(const aValue: Boolean);
 
     //Campaign
     procedure SetCampaignLastDifficulty(aValue: TKMMissionDifficulty);
@@ -257,6 +259,7 @@ type
     property AllowSnowHouses: Boolean read fGameTweaks_AllowSnowHouses write SetAllowSnowHouses;
     property InterpolatedRender: Boolean read fGameTweaks_InterpolatedRender write SetInterpolatedRender;
     property InterpolatedAnimations: Boolean read fGameTweaks_InterpolatedAnimations write SetInterpolatedAnimations;
+    property NewZoomBehaviour: Boolean read fGameTweaks_NewZoomBehaviour write SetNewZoomBehaviour;
 
     //Campaign
     property CampaignLastDifficulty: TKMMissionDifficulty read fCampaignLastDifficulty write SetCampaignLastDifficulty;
@@ -491,6 +494,7 @@ begin
     nGameTweaks := nGameCommon.AddOrFindChild('Tweaks');
       AllowSnowHouses     := nGameTweaks.Attributes['AllowSnowHouses'].AsBoolean(True);     // With restriction by ALLOW_SNOW_HOUSES
       InterpolatedRender  := nGameTweaks.Attributes['InterpolatedRender'].AsBoolean(False); // With restriction by ALLOW_INTERPOLATED_RENDER
+      NewZoomBehaviour    := nGameTweaks.Attributes['NewZoomBehaviour'].AsBoolean(True);
 
   // Campaign
   nCampaign := nGameSettings.AddOrFindChild('Campaign');
@@ -669,6 +673,7 @@ begin
     nGameTweaks := nGameCommon.AddOrFindChild('Tweaks');
       nGameTweaks.Attributes['AllowSnowHouses']     := fGameTweaks_AllowSnowHouses;
       nGameTweaks.Attributes['InterpolatedRender']  := fGameTweaks_InterpolatedRender;
+      nGameTweaks.Attributes['NewZoomBehaviour']    := fGameTweaks_NewZoomBehaviour;
 
   // Campaign
   nCampaign := nGameSettings.AddOrFindChild('Campaign');
@@ -1042,11 +1047,18 @@ begin
   Changed;
 end;
 
-procedure TKMGameSettings.SetInterpolatedAnimations(const Value: Boolean);
+procedure TKMGameSettings.SetInterpolatedAnimations(const aValue: Boolean);
 begin
   if not ALLOW_INTERPOLATED_ANIMS then Exit;
 
-  fGameTweaks_InterpolatedAnimations := Value;
+  fGameTweaks_InterpolatedAnimations := aValue;
+  Changed;
+end;
+
+procedure TKMGameSettings.SetNewZoomBehaviour(const aValue: Boolean);
+begin
+  fGameTweaks_NewZoomBehaviour := aValue;
+  Changed;
 end;
 
 

--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -4821,7 +4821,7 @@ begin
                           + Land^[Tmp, Xc + 1].RenderHeight * frac(inX)) / CELL_HEIGHT_DIV;
   end;
 
-  Result := Yc; //Assign something incase following code returns nothing
+  Result := inY; //Assign something incase following code returns nothing
 
   for I := Low(Ycoef) to High(Ycoef) - 1 do//check if cursor in a tile and adjust it there
   begin


### PR DESCRIPTION
Implements new camera behaviour which allows moving the camera outside the map and unrestricted zooming beyond the boundaries of the map.

To choose different zoom behaviours, change `ZoomBehaviour` in `Kam Remake Settings.xml` to:
- 0: Original behaviour
- 1: Semi-restrictive zoom
- 2: Unrestricted zoom

**Note:**
- The minimap camera lines sometimes move "janky" (For example, the bottom line moves a pixel before the top line does, and also the other way around), I'm not certain if this can easily be fixed due to how the line positions are calculated