### PR TITLE
use custom sorting algo from KM_Sort unit when compiling with FPC

### DIFF
--- a/src/ai/KM_AIGeneral.pas
+++ b/src/ai/KM_AIGeneral.pas
@@ -58,7 +58,11 @@ uses
   KM_Houses, KM_HouseBarracks,
   KM_ResHouses, KM_CommonUtils, KM_DevPerfLog, KM_DevPerfLogTypes,
   KM_UnitGroupTypes,
-  KM_ResTypes;
+  KM_ResTypes
+  {$IFDEF FPC}
+  , KM_Sort
+  {$ENDIF}
+  ;
 
 
 const
@@ -119,11 +123,20 @@ begin
   fOwner := aPlayer;
 end;
 
+function CompareKeys(const aKey1, aKey2): Integer;
+var
+  k1: Integer absolute aKey1;
+  k2: Integer absolute aKey2;
+begin
+  if      k1 < k2 then Result := -1
+  else if k1 > k2 then Result := +1
+  else                 Result :=  0;
+end;
 
 procedure TKMGeneral.Save(SaveStream: TKMemoryStream);
 var
   uid: Integer;
-  keyArray : TArray<Integer>;
+  keyArray: TArray<Integer>;
 begin
   SaveStream.PlaceMarker('AIGeneral');
   SaveStream.Write(fOwner);
@@ -135,7 +148,11 @@ begin
   SaveStream.PlaceMarker('AIGeneral_unitsEquipOrdered');
   SaveStream.Write(fUnitsEquipOrdered.Count);
   keyArray := fUnitsEquipOrdered.Keys.ToArray;
+  {$IFNDEF FPC}
   TArray.Sort<Integer>(keyArray);
+  {$ELSE}
+  SortCustom(keyArray, Low(keyArray), High(keyArray), SizeOf(keyArray[0]), CompareKeys);
+  {$ENDIF}
 
   for uid in keyArray do
     SaveStream.Write(uid);

--- a/src/game/KM_GameSavePoints.pas
+++ b/src/game/KM_GameSavePoints.pas
@@ -3,7 +3,11 @@ unit KM_GameSavePoints;
 interface
 uses
   SyncObjs, Generics.Collections,
-  KM_CommonClasses, KM_WorkerThread;
+  KM_CommonClasses, KM_WorkerThread
+  {$IFDEF FPC}
+  , KM_Sort
+  {$ENDIF}
+  ;
 
 type
   TKMSavePoint = class
@@ -307,6 +311,17 @@ begin
   end;
 end;
 
+{$IFDEF FPC}
+function CompareKeys(const aKey1, aKey2): Integer;
+var
+  k1: Cardinal absolute aKey1;
+  k2: Cardinal absolute aKey2;
+begin
+  if      k1 < k2 then Result := -1
+  else if k1 > k2 then Result := +1
+  else                 Result :=  0;
+end;
+{$ENDIF}
 
 procedure TKMSavePointCollection.Save(aSaveStream: TKMemoryStream);
 var
@@ -323,7 +338,11 @@ begin
     aSaveStream.Write(fSavePoints.Count);
 
     keyArray := fSavePoints.Keys.ToArray;
+    {$IFNDEF FPC}
     TArray.Sort<Cardinal>(keyArray);
+    {$ELSE}
+    SortCustom(keyArray, Low(keyArray), High(keyArray), SizeOf(keyArray[0]), CompareKeys);
+    {$ENDIF}
 
     // todo: potential OutOfMemory error in this cycle
     for key in keyArray do

--- a/src/media/KM_ScriptSound.pas
+++ b/src/media/KM_ScriptSound.pas
@@ -67,7 +67,11 @@ uses
   SysUtils,
   KM_Game,
   KM_HandsCollection, KM_HandTypes,
-  KM_Sound;
+  KM_Sound
+  {$IFDEF FPC}
+  , KM_Sort
+  {$ENDIF}
+  ;
 
 
 { TKMScriptSound }
@@ -298,6 +302,15 @@ begin
   fListener := KMPointF(X, Y);
 end;
 
+function CompareKeys(const aKey1, aKey2): Integer;
+var
+  k1: Integer absolute aKey1;
+  k2: Integer absolute aKey2;
+begin
+  if      k1 < k2 then Result := -1
+  else if k1 > k2 then Result := +1
+  else                 Result :=  0;
+end;
 
 procedure TKMScriptSoundsManager.Save(SaveStream: TKMemoryStream);
 var
@@ -328,7 +341,11 @@ begin
   SaveStream.Write(fSoundRemoveRequests.Count);
 
   keyArray := fSoundRemoveRequests.Keys.ToArray;
+  {$IFNDEF FPC}
   TArray.Sort<Integer>(keyArray);
+  {$ELSE}
+  SortCustom(keyArray, Low(keyArray), High(keyArray), SizeOf(keyArray[0]), CompareKeys);
+  {$ENDIF}
   for key in keyArray do
   begin
     SaveStream.Write(key);

--- a/src/unused/KM_PerfLog.pas
+++ b/src/unused/KM_PerfLog.pas
@@ -2,7 +2,11 @@ unit KM_PerfLog;
 {$I KaM_Remake.inc}
 interface
 uses
-  Generics.Collections;
+  Generics.Collections
+  {$IFDEF FPC}
+  , KM_Sort
+  {$ENDIF}
+  ;
 
 
 type
@@ -216,6 +220,27 @@ begin
   fTimeEnter[aSection] := 0;
 end;
 
+{$IFDEF FPC}
+function CompareTicks(const aKey1, aKey2): Integer;
+var
+  k1: Cardinal absolute aKey1;
+  k2: Cardinal absolute aKey2;
+begin
+  if      k1 < k2 then Result := -1
+  else if k1 > k2 then Result := +1
+  else                 Result :=  0;
+end;
+
+function CompareSects(const aKey1, aKey2): Integer;
+var
+  k1: TKMPerfSection absolute aKey1;
+  k2: TKMPerfSection absolute aKey2;
+begin
+  if      k1 < k2 then Result := -1
+  else if k1 > k2 then Result := +1
+  else                 Result :=  0;
+end;
+{$ENDIF}
 
 procedure TKMPerfLog.SaveToFile(const aFilename: UnicodeString);
 var
@@ -239,7 +264,11 @@ begin
   S := TStringList.Create;
 
   TicksArray := fTickTimes.Keys.ToArray;
+  {$IFNDEF FPC}
   TArray.Sort<Cardinal>(TicksArray);
+  {$ELSE}
+  SortCustom(TicksArray, Low(TicksArray), High(TicksArray), SizeOf(TicksArray[0]), CompareTicks);
+  {$ENDIF}
 
 //  Str := 'Tick   '; //7
   Str := '       ';
@@ -261,7 +290,11 @@ begin
     SectDict := fTickTimes.Items[TickKey];
 
     SectsArray := SectDict.Keys.ToArray;
+    {$IFNDEF FPC}
     TArray.Sort<TKMPerfSection>(SectsArray);
+    {$ELSE}
+    SortCustom(SectsArray, Low(SectsArray), High(SectsArray), SizeOf(SectsArray[0]), CompareSects);
+    {$ENDIF}
 
     FastTick := False;
     Str := Format('%6d:', [TickKey]);


### PR DESCRIPTION
all current implementations of FP do not support generically sorting arrays like Delphi does, so we're switching to SortCustom procedure from KM_Sort unit when compiling with FPC