### PR TITLE
FPC: fix Error: Global Generic template references static symtable

### DIFF
--- a/src/utils/algorithms/BinaryHeapGen.pas
+++ b/src/utils/algorithms/BinaryHeapGen.pas
@@ -5,7 +5,6 @@ unit BinaryHeapGen;
 interface
 uses Generics.Collections;
 
-
 type
   TComparator<T: class> = function(A, B: T) : Boolean of object;
 
@@ -31,13 +30,13 @@ type
     procedure UpdateItem(x: T);
   end;
 
+const
+  BINARY_HEAP_GEN_GROW_FACTOR = 1.618; // golden ratio
+
 
 implementation
 uses
   SysUtils;
-
-const
-  GROW_FACTOR = 1.618; // golden ratio
 
 
 { TBinaryHeap }
@@ -88,7 +87,7 @@ end;
 procedure TObjectBinaryHeap<T>.Push(aItem: T);
 begin
   if Length(fItems) <= fCount then
-    SetLength(fItems, Round(fCount * GROW_FACTOR));
+    SetLength(fItems, Round(fCount * BINARY_HEAP_GEN_GROW_FACTOR));
 
   fItems[fCount] := aItem;
   Inc(fCount);


### PR DESCRIPTION
this happened because constant had been defined within implementation section and used in a generic code what is prohibited by Free Pascal 

the constant must be defined in the interface to make it compile