### PR TITLE
FPC Lazarus KM_SettingsXML unit compilation fix

### DIFF
--- a/src/settings/KM_SettingsXML.pas
+++ b/src/settings/KM_SettingsXML.pas
@@ -13,7 +13,7 @@ type
   protected
     fRoot: TKMXmlNode;
     procedure LoadFromFile(const aPath: string); override;
-    procedure SaveToFile(const aPath: string); override;
+    procedure SaveToFile(const aPath: UnicodeString); override;
   public
     constructor Create;
     destructor Destroy; override;
@@ -56,7 +56,7 @@ begin
 end;
 
 
-procedure TKMSettingsXML.SaveToFile(const aPath: string);
+procedure TKMSettingsXML.SaveToFile(const aPath: UnicodeString);
 begin
   inherited;
 


### PR DESCRIPTION
TKMSettingsXML.SaveToFile must override a virtual method of the base class with a correct type UnicodeString rather than an ordinary string