### PR TITLE
unit KM_MainSettings: remove using Forms when FPC is defined

### DIFF
--- a/src/settings/KM_MainSettings.pas
+++ b/src/settings/KM_MainSettings.pas
@@ -3,7 +3,6 @@ unit KM_MainSettings;
 interface
 uses
   Classes,
-  {$IFDEF FPC}Forms,{$ENDIF}   //Lazarus do not know UITypes
   {$IFDEF WDC}UITypes,{$ENDIF} //We use settings in console modules
   KM_Resolutions,
   KM_Defaults,


### PR DESCRIPTION
this gets free the module from double using Forms since there is Forms used in implementation section