### PR TITLE
fix compilation with FPC + Lazarus of campaigns sorting algorithm

### DIFF
--- a/src/mission/KM_Campaigns.pas
+++ b/src/mission/KM_Campaigns.pas
@@ -171,15 +171,11 @@ uses
   SysUtils, Math, KromUtils,
   KM_GameParams,
   KM_Resource, KM_ResLocales, KM_ResSprites, KM_ResTypes,
-  KM_Log, KM_Defaults, KM_CommonUtils, KM_FileIO
+  KM_Log, KM_Defaults, KM_CommonUtils, KM_FileIO, KM_Sort
   {$IFDEF FPC}
   , Generics.Defaults
   {$ENDIF}
   ;
-
-type
-  TKMCampaignCompType = Function(constref A, B: TKMCampaign) : Boolean;
-
 
 const
   CAMP_HEADER_V1 = $FEED; //Just some header to separate right progress files from wrong
@@ -236,7 +232,7 @@ begin
 end;
 
 
-{$IFDEF FPC}
+{$IFDEF Unix}
 // Return Negative if A < B, Positive if B < A, 0 otherwise
 function TKMCampaignComparatorThreeWay(constref A, B: TKMCampaign): LongInt;
 begin
@@ -248,33 +244,9 @@ end;
 
 
 procedure TKMCampaignsCollection.SortCampaigns;
-
-  {$IFNDEF FPC}
-  procedure SelectionSort(var aList: TList<TKMCampaign>; idxFirst, idxLast: Integer; Comp: TKMCampaignCompType);
-  var
-    I, K, L, J: Integer;
-  begin
-    if not (idxFirst < idxLast) then Exit;
-
-    I := idxFirst;
-    L := idxLast;
-
-    while I < L do
-    begin
-         J := I;
-         for K := J + 1 to L do
-             if Comp(aList.List[K], aList.List[J]) then
-                J := K;
-         if (I <> J) then
-            SwapInt(NativeUInt(aList.List[I]), NativeUInt(aList.List[J]));
-         Inc(I);
-    end;
-  end;
-  {$ENDIF}
-
 begin
-  {$IFNDEF FPC}
-  SelectionSort(fList, 0, Count - 1, @TKMCampaignComparator);
+  {$IFNDEF Unix}
+  SelectionSort<TKMCampaign>(fList, 0, Count - 1, @TKMCampaignComparator);
   {$ELSE}
   fList.Sort(@TKMCampaignComparatorThreeWay);
   {$ENDIF}

--- a/src/utils/algorithms/KM_Sort.pas
+++ b/src/utils/algorithms/KM_Sort.pas
@@ -2,8 +2,15 @@ unit KM_Sort;
 {$I KaM_Remake.inc}
 interface
 
+uses
+    KromUtils,
+    Generics.Collections, Generics.Defaults;
+
 type
   TKMCompFunc = function (const aElem1, aElem2): Integer;
+  TKMSelectionSortCompType<T> = Function(constref A, B: T) : Boolean;
+
+procedure SelectionSort<T>(var aList: TList<T>; idxFirst, idxLast: Integer; Comp: TKMSelectionSortCompType<T>);
 
 procedure SortCustom(var aArr; aMinIdx, aMaxIdx, aSize: Integer; aCompFunc: TKMCompFunc);
 
@@ -61,6 +68,39 @@ begin
 
   SetLength(Buf, aSize);
   QuickSort(aMinIdx * aSize, aMaxIdx * aSize, Buf[0]);
+end;
+
+procedure SelectionSort<T>(var aList: TList<T>; idxFirst, idxLast: Integer; Comp: TKMSelectionSortCompType<T>);
+var
+  I, K, L, J: Integer;
+begin
+  if not (idxFirst < idxLast) then Exit;
+
+  I := idxFirst;
+  L := idxLast;
+
+  while I < L do
+  begin
+       J := I;
+       for K := J + 1 to L do
+           if
+           {$IFDEF Unix}
+           Comp(aList.Items[I], aList.Items[J])
+           {$ELSE}
+           Comp(aList.List[I], aList.List[J])
+           {$ENDIF}
+           then
+              J := K;
+       if (I <> J) then
+       begin
+         {$IFDEF Unix}
+         aList.Exchange(I, J);
+         {$ELSE}
+         SwapInt(NativeUInt(aList.List[I]), NativeUInt(aList.List[J]));
+         {$ENDIF}
+       end;
+       Inc(I);
+  end;
 end;
 
 end.


### PR DESCRIPTION
FPC and Lazarus on Linux do not have List<T>.List[] property, but List<T> fortunately has Sort() method at Linux platform with a comparator to give from a call site

Please, consider these changes to merge them in. The previous business logic of Windows's implementation has been preserved