### PR TITLE
disable gathering information about performance on Linux

### DIFF
--- a/src/KM_GameApp.pas
+++ b/src/KM_GameApp.pas
@@ -1383,17 +1383,21 @@ end;
 
 
 procedure TKMGameApp.UpdatePerflog;
+{$IFNDEF Unix}
 {$IFDEF PERFLOG}
 var
   memUsed, stackUsed: NativeUInt;
 {$ENDIF}
+{$ENDIF}
 begin
+  {$IFNDEF Unix}
   {$IFDEF PERFLOG}
   memUsed := GetMemUsed;
   stackUsed := GetCommittedStackSize;
 
   gPerfLogs.SectionAddValue(psMemUsed, memUsed div (10*1024), fGlobalTickCount, IntToStr(memUsed div (1024*1024)) + 'Mb');
   gPerfLogs.SectionAddValue(psStackUsed, stackUsed div 128, fGlobalTickCount, IntToStr(stackUsed div 1024) + 'Kb');
+  {$ENDIF}
   {$ENDIF}
 end;
 


### PR DESCRIPTION
this is impossible to assess performance on Linux since the latter does not have such functions used in the code in WDC version