### PR TITLE
KM_CommonUtils unit: add AtomicIncrement and AtomicDecrement functions

### DIFF
--- a/src/utils/KM_CommonUtils.pas
+++ b/src/utils/KM_CommonUtils.pas
@@ -175,7 +175,9 @@ uses
 
   {$IFDEF FPC}
   {$IFDEF Unix}
-  function AtomicExchange (var Target: longint;Source : longint) : longint; external name 'FPC_INTERLOCKEDEXCHANGE';
+  function AtomicExchange(var Target: longint; Source: longint): longint; external name 'FPC_INTERLOCKEDEXCHANGE';
+  function AtomicIncrement(var Target: longint): longint;
+  function AtomicDecrement(var Target: longint): longint;
   {$ENDIF}
   {$ENDIF}
 
@@ -2070,6 +2072,24 @@ begin
   if not Result then
     aErrorStr := Format('Error executing method (%d tries) %s for parameters: [%s, %s]', [aAttemps, aMethodName, aStrParam1, aStrParam2]);
 end;
+
+
+{$IFDEF FPC}
+{$IFDEF Unix}
+
+function AtomicIncrement(var Target: longint) : longint;
+begin
+  Result := InterlockedIncrement(Target);
+end;
+
+
+function AtomicDecrement(var Target: longint) : longint;
+begin
+  Result := InterlockedDecrement(Target);
+end;
+
+{$ENDIF}
+{$ENDIF}
 
 
 initialization


### PR DESCRIPTION
for FPC + Unix mode we need AtomicIncrement and AtomicDecrement functions since they are absent in system modules and headers