### PR TITLE
Updated event comment to match behavior

### DIFF
--- a/src/scripting/KM_ScriptingEvents.pas
+++ b/src/scripting/KM_ScriptingEvents.pas
@@ -1018,10 +1018,10 @@ end;
 
 
 //* Version: 6587
-//* Happens when a unit is attacked (shot at by archers or hit in melee).
-//* Attacker is always a warrior (could be archer or melee).
+//* Happens when a unit is attacked (shot at by archers, hit in melee, or shot by a tower).
+//* Attacker can be a warrior, recruit in tower or unknown (-1).
 //* This event will occur very frequently during battles.
-//* aAttacker: Warrior who attacked the unit
+//* aAttacker: Unit who attacked the unit
 procedure TKMScriptEvents.ProcUnitAttacked(aUnit, aAttacker: TKMUnit);
 begin
   if MethodAssigned(evtUnitAttacked) then


### PR DESCRIPTION
Based on discussion in discord, the OnUnitAttacked event triggers when the unit is attacked by a tower, despite it's description.

Ref: https://discord.com/channels/338733130565287936/646798830192295936/1210504489505914890