### PR TITLE
Change workshops LIFO items

### DIFF
--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -1972,7 +1972,7 @@ begin
     if gRes.Houses[fType].IsWorkshop and (aCount > 0) then
     begin
       count := aCount;
-      for p := 0 to 19 do
+      for p := 19 downto 0 do
         if fWareOutPool[p] = I then
           begin
             fWareOutPool[p] := 0;


### PR DESCRIPTION
Take from workshops last added item first, because f.e. shields can be on top of each other in house