### PR TITLE
add gametime to script logs

### DIFF
--- a/src/scripting/KM_ScriptErrorHandler.pas
+++ b/src/scripting/KM_ScriptErrorHandler.pas
@@ -185,7 +185,7 @@ procedure TKMScriptErrorHandler.HandleScriptErrorString(aType: TKMScriptErrorTyp
     begin
       if DEBUG_SCRIPTING_EXEC or (fLogLinesCnt < fLogLinesCntMax) then
       begin
-        gLog.AddTime('Script: [gametime ' + TickToTimeStr(gGameParams.Tick) + '] ' + aLogErrorMsg); //log the error to global game log
+        gLog.AddTime('Script: [gametime ' + TickToTimeStr(gGameParams.Tick) + '.' + IntToStr(gGameParams.Tick mod 10)  + '] ' + aLogErrorMsg); //log the error to global game log
         AssignFile(fl, fScriptLogFile);
         if not FileExists(fScriptLogFile) then
           Rewrite(fl)


### PR DESCRIPTION
fixes https://trello.com/c/wHpBmRIZ/2237-scripts-add-game-time-on-script-error
ie.
18:00:41.648   196,529s    9371ms  14408    Script: [gametime 00:04:34.5] Invalid parameter(s) passed to Actions.PlanRemove: -1, -1, -1
