### PR TITLE
remove StayOnTop property from “KaM Remake” loading window

### DIFF
--- a/src/forms/KM_FormLoading.pas
+++ b/src/forms/KM_FormLoading.pas
@@ -45,9 +45,15 @@ end;
 
 procedure TFormLoading.LoadingStep;
 begin
-  if not Visible then Exit;
-  Bar1.StepIt;
-  Refresh;
+  try
+	  if not Visible then Exit;
+	  Bar1.StepIt;
+	  Refresh;
+	  Assert(1=0);
+  except
+      FormStyle := fsNormal;
+      raise;
+  end;
 end;
 
 


### PR DESCRIPTION
Done when an exception during loading is caught.

fixes https://trello.com/c/FR42P0Qi/2299-bug-report-window-on-125-screen-scale