### PR TITLE
Add gold smelter to list of buildings, in a corner case, where there …

### DIFF
--- a/Todo/Changelog Beta.txt
+++ b/Todo/Changelog Beta.txt
@@ -29,6 +29,7 @@ Game:
  + Fixed map flip for lava tiles in map editor
  + Slightly improved description of FPS cap in UI
  + Market ratio changes for trades to gold ore: stone 7 -> 8, pig/skin 1/2 -> 1, wooden shield 1 -> 2
+ + Fixed when there were not enough coal mines in city, no coal was brought to Metallurgists
 
 Maps:
  + Added The Fall of House Fennford by Strangelove

--- a/src/hands/KM_HandLogistics.pas
+++ b/src/hands/KM_HandLogistics.pas
@@ -1509,7 +1509,7 @@ begin
     //evenly between places rather than caring about route length.
     //This means weapon and armour smiths should get same amount of iron, even if one is closer to the smelter.
     if fDemand[dWT,iD].Loc_House.IsComplete
-      and (gRes.Houses[fDemand[dWT,iD].Loc_House.HouseType].DoesOrders or (fDemand[dWT,iD].Loc_House.HouseType = htIronSmithy))
+      and (gRes.Houses[fDemand[dWT,iD].Loc_House.HouseType].DoesOrders or (fDemand[dWT,iD].Loc_House.HouseType = htIronSmithy) or (fDemand[dWT,iD].Loc_House.HouseType = htMetallurgists))
       and (aOfferCnt <= 2) //Little resources to share around
       and (fDemand[dWT,iD].Loc_House.CheckWareIn(dWT) <= 1) then //Few resources already delivered
     begin


### PR DESCRIPTION
…is not enough of a resource (one of 4 which use distribution sliders) - now gold production no longer halts in case of low coal supply

fixes https://trello.com/c/QdBJOq5S/2329-when-there-is-not-enough-coal-in-base-iron-always-has-priority-over-gold