### PR TITLE
Change default ware distribution for coal and wood, do not save ware …

### DIFF
--- a/Todo/Changelog Beta.txt
+++ b/Todo/Changelog Beta.txt
@@ -29,6 +29,8 @@ Game:
 + Fixed map flip for lava tiles in map editor
 + Slightly improved description of FPS cap in UI
 + Market ratio changes for trades to gold ore: stone 7 -> 8, pig/skin 1/2 -> 1, wooden shield 1 -> 2
++ Change default ware distribution for coal from 5344 to 3533, for wood from 34 to 25
++ Disable by default setting "Save ware distribution between games" in best interest of players who do not know about this behaviour
 
 Maps:
 + Added The Fall of House Fennford by Strangelove

--- a/src/hands/KM_WareDistribution.pas
+++ b/src/hands/KM_WareDistribution.pas
@@ -11,8 +11,8 @@ const
   //The number means how many items should be in houses input max, and also affects delivery priority.
   DISTRIBUTION_DEFAULTS: array [1..4, 1..4] of Byte = (
     (5, 5, 0, 0),
-    (5, 3, 4, 4),
-    (3, 4, 0, 0),
+    (3, 5, 3, 3),
+    (2, 5, 0, 0),
     (4, 5, 3, 0)
   );
 

--- a/src/settings/KM_GameSettings.pas
+++ b/src/settings/KM_GameSettings.pas
@@ -473,7 +473,7 @@ begin
     // Ware distribution
     nGameWareDistribution := nGameCommon.AddOrFindChild('WareDistribution');
       fWareDistribution.LoadFromStr(nGameWareDistribution.Attributes['Value'].AsString(''));
-      fSaveWareDistribution := nGameWareDistribution.Attributes['SavedBetweenGames'].AsBoolean(True); //Enabled by default
+      fSaveWareDistribution := nGameWareDistribution.Attributes['SavedBetweenGames'].AsBoolean(False); //Enabled by default
 
     // Misc
     nGameMisc := nGameCommon.AddOrFindChild('Misc');


### PR DESCRIPTION
…distribution by default

Workarounds issue https://trello.com/c/QdBJOq5S/2329-when-there-is-not-enough-coal-in-base-iron-always-has-priority-over-gold
Reasons are outlined in Trello ticket.