### PR TITLE
Disable compiler optimizations for Release config of Script Validator

### DIFF
--- a/Utils/ScriptValidator/ScriptValidator.dproj
+++ b/Utils/ScriptValidator/ScriptValidator.dproj
@@ -75,6 +75,7 @@
         <DCC_DebugInformation>0</DCC_DebugInformation>
         <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
         <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+		<DCC_Optimize>false</DCC_Optimize>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>


### PR DESCRIPTION
Fixes https://trello.com/c/Qx0W5rnu/2337-scriptvalidator-does-not-build-in-release-configuration