### PR TITLE
fix InitQueue Integer overflow

### DIFF
--- a/src/navmesh/KM_NavMeshArmyVectorField.pas
+++ b/src/navmesh/KM_NavMeshArmyVectorField.pas
@@ -896,6 +896,9 @@ procedure TKMArmyVectorField.InitQueue(const aGroupsPoly: TKMWordArray; aCnt: Wo
 var
   K: Integer;
 begin
+  if aCnt = 0 then
+    Exit;
+
   Inc(fVisitedIdx);
   for K := 0 to aCnt - 1 do
     AddPolyToQueue(ffRally, aGroupsPoly[K]);


### PR DESCRIPTION
In the `EstimateCombatLine` function (_line 1154_), the queue initialization function `InitQueue(GroupsPoly, Cnt);` is called.
At this point, the local variable `Cnt` (of type `Integer`) can be equal to `0` if no group is close enough to the battle line.
The function `InitQueue(const aGroupsPoly: TKMWordArray; aCnt: Word);` takes a second argument as an unsigned `Word`. When passing zero, `aCnt` becomes `0`.
Inside `InitQueue` (_line 900_), we enter a loop `for K := 0 to aCnt - 1 do`
Since `aCnt` is of type `Word`, calculating `aCnt - 1` when `aCnt = 0` results in an attempt to evaluate `-1` within the unsigned `Word` type. This immediately triggers an `EIntOverflow exception` and crashes the game.