### PR TITLE
Fix Access Violation in HandleMessagePlayersList when the roster no longer contains us

### DIFF
--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -1394,6 +1394,9 @@ begin
     // Our index could have changed on players add/removal
     fMySlotIndex := fNetRoom.NicknameToLocal(fMyNickname);
 
+    if fMySlotIndex = -1 then
+      Exit; // We are no longer in the room, wait for disconnect
+
     if Assigned(OnPlayersSetup) then OnPlayersSetup;
 
     if Assigned(OnUpdateMinimap)


### PR DESCRIPTION
Fixes #315 — `TKMGamePlayInterface.AlliesOnPlayerSetup`, `EAccessViolation`, *Read of address `0000005D`*.

The original description of this PR was a guess and it was wrong. It is replaced below by the analysis traced from the r16020 crash report. **The code change is unchanged.**

## What the crash report proves

Against the r16020 sources, the two reported lines are exactly:

* `KM_Networking.pas:1397` → `if Assigned(OnPlayersSetup) then OnPlayersSetup;` in `HandleMessagePlayersList`
* `KM_InterfaceGamePlay.pas:3217` → `Button_Menu_ReturnLobby.Enabled := not gNetworking.MyRoomSlot.VotedYes`

The faulting address identifies the `nil` pointer beyond doubt. `0000005D` is 93, and `VotedYes` sits at offset **93** in `TKMNetRoomSlot` (32-bit, default `{$A8}`/`{$Z1}`, `TKMNetHandleIndex = SmallInt`):

| offset | field |
|---|---|
| 0 | VMT pointer |
| 4 / 8 | `fNickname` / `fLangCode` |
| 12 | `fIndexOnServer` (SmallInt) + 2 pad |
| 16 | `fFlagColor` |
| 20..59 | `fPings` — 20 x Word |
| 60 | `fPingPos` + 3 pad |
| 64 | `fFPS` |
| 68 | `PlayerNetType` + 3 pad |
| 72 / 76 | `StartLocation` / `Team` |
| 80..85 | `ReadyToStart`, `ReadyToPlay`, `ReadyToReturnToLobby`, `HasMapOrSave`, `Connected`, `Dropped` + 2 pad |
| 88 | `LastSentCommandsTick` |
| 92 | `DownloadInProgress` |
| **93** | **`VotedYes` -> `$5D`** |

`GetMyRoomSlot` and `GetRoomSlot` are not `inline`, so the fault is in `AlliesOnPlayerSetup`'s own code, i.e. after `nil` was returned — it is not a crash inside the getters.

## The mechanism

`HandleMessagePlayersList` recomputes our index and then fires the event unconditionally:

```pascal
fMySlotIndex := fNetRoom.NicknameToLocal(fMyNickname);

if Assigned(OnPlayersSetup) then OnPlayersSetup;
```

If our nickname is absent from the roster that just arrived, `NicknameToLocal` returns `-1`, `TKMNetRoom.GetRoomSlot` correctly returns `nil` for an out-of-range index, and `AlliesOnPlayerSetup` dereferences it on its first statement.

## Why a roster without us can arrive legitimately

**Not** because we were kicked or dropped mid-game — that was the wrong guess in the old description. During play a lost player only gets `Connected := False` / `Dropped := True` and keeps the slot. Every place that actually *removes* a slot (`RemServerPlayer` in the `mkClientLost` / `mkDisconnect` handlers, `RemDisconnectedPlayers` in `ReturnToLobby`) runs only when the host's `fNetGameState` is **not** `lgsGame` / `lgsLoading`.

So the roster loses our nickname only once **the host is already back in the lobby while our game is still running** — the classic case being: we lose the connection, the others vote to return to the lobby, `ReturnToLobby` drops the disconnected players, and `TKMMenuLobby.ReturnToLobby` → `SelectSave` → `SendPlayerListAndRefreshPlayersSetup` broadcasts the new roster.

We are still there to receive it because:

* the server admits a client into a room mid-game with no checks (`mkJoinRoom` only asks for a password in `mgsLobby`, deliberately, so clients can reconnect);
* it relays `NET_ADDRESS_OTHERS` purely by room membership — it knows nothing about the host's player list;
* a refused `mkAskToReconnect` does **not** close the socket (`GameMPDisconnect` → `AttemptReconnection` when the state is `lgsReconnecting`);
* `mkPlayersList` is in `NET_ALLOWED_PACKETS_SET[lgsReconnecting]`.

The result is a client the host no longer counts as a player, still sitting in the room and still receiving every roster broadcast.

Two details from the reporter's log confirm the order of events. `mkAskToReconnect` is accepted **only** in `lgsGame`, so the `mkRefuseReconnect` we received proves the host was still in the game at that moment and our slot still existed; it disappeared ~2 s later, which is exactly the time the return-to-lobby save takes. And the `Server stopped responding` line printed shortly *before* `Exception occurred` is the aftermath, not the cause — `PacketRecieve` begins with `if not Connected then Exit`, so the packet could only have been handled while the socket was still up.

## On "we should not be processing `mkPlayersList` in the first place"

> If this analysis is true, we should not be processing the `mkPlayersList` in the first place.

Two points, now that the analysis is settled:

1. **This is not a packet race.** You are right that TCP preserves the order of packets between two peers, and nothing here depends on reordering. The host sends a roster that is correct *for the host*; it simply no longer describes us, because the host has left the game and we have not. Whichever way the packets are ordered, the roster is the same.
2. **The reconnect path needs this packet.** `HandleMessagePlayersList` is the only place `fMySlotIndex` is recomputed from the nickname, and on a successful reconnect the host sends `SendPlayerListAndRefreshPlayersSetup` *before* `mkReconnectionAccepted`. Removing `mkPlayersList` from `NET_ALLOWED_PACKETS_SET[lgsReconnecting]` would leave a reconnected client with a stale or `-1` index, so it would break reconnection instead of fixing it.

That leaves the guard as the correct minimal fix: the roster is valid, we are simply no longer in it, and there is nothing to refresh until the disconnect arrives.

## The fix

```pascal
if fMySlotIndex = -1 then
  Exit; // We are no longer in the room, wait for disconnect
```

It also covers the second unguarded `MyRoomSlot` dereference further down the same routine (`oldLoc <> MyRoomSlot.StartLocation` in the `OnUpdateMinimap` branch). That one is dormant in game — `MultiplayerRig` sets `OnUpdateMinimap := nil` — but live in the lobby, so no separate fix is needed for it.

## Test

Reproduced by `MP_RosterWithoutUs` in the multiplayer test harness of #331: red on master with the same stack as the crash report, green with this commit. It does not affect #316 (`MP_RosterZeroLoc` stays red) — there our slot is present, so this guard never fires; that one is a different defect with its own fix in #332.

Rebased onto current `master`.
