### PR TITLE
Barracks recruits list must own a counted reference to every recruit (#300)

### DIFF
--- a/Utils/Testing_GameTests/KM_Test_Recruits.pas
+++ b/Utils/Testing_GameTests/KM_Test_Recruits.pas
@@ -1,0 +1,683 @@
+unit KM_Test_Recruits;
+{$I KaM_Remake.inc}
+interface
+uses
+  KM_Test;
+
+
+type
+  // Barracks keep their own list of the recruits sitting inside (TKMHouseBarracks.fRecruitsList).
+  // EquipWarrior takes fRecruitsList[0] for granted and calls KillInHouse on it, which asserts
+  // that the unit is inside some house. These tests verify that the list stays in sync with reality,
+  // since a stale entry means either a killed (and freed) unit or a unit that has left the barracks.
+  //
+  // Note: no game units are used in the interface section on purpose (as in every other test unit),
+  // that keeps the units compilation order intact. Hence barracks is kept by UID, not by pointer,
+  // which is safer anyway - a destroyed house could be freed at any moment
+  TKMTest_RecruitsBase = class abstract(TKMTest)
+  protected
+    fBarracksUID: Integer;
+    fError: string;
+
+    procedure SetUpScene(aRecruitsCnt: Integer; aAddSchool: Boolean);
+
+    // Errors found while ticking are recorded rather than raised: the framework calls CheckResult
+    // from a finally block, so it is safer to report them from CheckResult itself
+    procedure RecordError(const aError: string);
+    procedure CheckRecordedError;
+
+    // Every listed recruit must be a living recruit inside that very barracks.
+    // The opposite is not always true: recruit is unregistered as soon as he starts walking out,
+    // but keeps his InHouse until the walk is complete, hence 'less or equal' here
+    function CheckNoPhantoms(aTick: Cardinal): Boolean;
+
+    function ListedRecruitsCnt: Integer;
+    function AliveRecruitsCnt: Integer;
+    function RecruitObjectsCnt: Integer; // Including the dead ones, which are not freed yet
+    function BarracksExists: Boolean;
+  end;
+
+  // Recruit is dismissed while sitting inside the barracks. If the dismiss does start, he is killed
+  // inside the school (TKMTaskDismiss), which never unregisters him from the barracks
+  TKMTest_Recruit_Dismiss = class(TKMTest_RecruitsBase)
+  private
+    fDismissStarted: Boolean;
+  protected
+    procedure SetUp; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+  // Barracks with the 'do not accept recruits' flag clears the recruit Home while he is still inside
+  // it (ProceedHouseClosedForWorker, wGoingForEating branch), so that Home and InHouse diverge -
+  // the only divergence the game code admits, see the comment in TKMUnitActionGoInOut.WalkOut.
+  // Then the Inn is destroyed before the recruit steps out, and he is left inside with no Home at all
+  TKMTest_Recruit_HomeLostWhileInside = class(TKMTest_RecruitsBase)
+  private
+    fStage: Byte;
+    fStageTick: Cardinal;
+  protected
+    procedure SetUp; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+  // Hungry recruit with no Inn around goes out of the barracks to show he is hungry and comes back.
+  // Registration in the list is keyed on Home, unregistration on InHouse - check they stay in sync
+  TKMTest_Recruit_HungryCycle = class(TKMTest_RecruitsBase)
+  private
+    fStage: Byte;
+  protected
+    procedure SetUp; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+  // Recruit is killed while sitting inside the barracks
+  TKMTest_Recruit_KilledInside = class(TKMTest_RecruitsBase)
+  protected
+    procedure SetUp; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+  // Barracks keep raw pointers to their recruits in fRecruitsList without taking a counted reference,
+  // unlike every other unit reference in the game (see TKMHandEntityPointer.GetPointer). A recruit
+  // that gets closed while being listed is then freed right away - TKMUnitsCollection.UpdateState
+  // frees the units with PointerCount = 0 - and the barracks are left with a dangling pointer, which
+  // EquipWarrior happily dereferences. So: a listed recruit must be referenced by the barracks,
+  // and once he is equipped and unregistered, that reference must be released (no leak)
+  TKMTest_Recruit_ListOwnsPointer = class(TKMTest_RecruitsBase)
+  private
+    fEquipTick: Cardinal;
+  protected
+    procedure SetUp; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+  // Barracks with recruits inside is demolished, recruits should be placed outside and survive
+  TKMTest_Recruit_BarracksDemolished = class(TKMTest_RecruitsBase)
+  protected
+    procedure SetUp; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+
+implementation
+uses
+  SysUtils,
+  KM_Defaults, KM_Points,
+  KM_GameApp, KM_HandsCollection, KM_HandTypes,
+  KM_Houses, KM_HouseBarracks, KM_Units,
+  KM_ResTypes;
+
+const
+  BARRACKS_LOC: TKMPoint = (X: 16; Y: 16);
+  SCHOOL_LOC: TKMPoint = (X: 8; Y: 8);
+  INN_LOC: TKMPoint = (X: 8; Y: 20);
+  SETTLE_TICKS = 10; // Ticks to let the scene settle down before we touch anything
+
+
+// Barracks are accessed by UID, since a destroyed house could be freed at any moment
+function GetBarracks(aUID: Integer): TKMHouseBarracks;
+begin
+  Result := nil;
+
+  var H := gHands.GetHouseByUID(aUID);
+  if (H <> nil) and not H.IsDestroyed and (H is TKMHouseBarracks) then
+    Result := TKMHouseBarracks(H);
+end;
+
+
+function FindRecruit: TKMUnit;
+begin
+  Result := nil;
+  for var I := 0 to gHands[0].Units.Count - 1 do
+  begin
+    var U := gHands[0].Units[I];
+    if (U <> nil) and not U.IsDead and (U.UnitType = utRecruit) then
+      Exit(U);
+  end;
+end;
+
+
+function RecruitsInHouseCnt(aHouse: TKMHouse): Integer;
+begin
+  Result := 0;
+  for var I := 0 to gHands[0].Units.Count - 1 do
+  begin
+    var U := gHands[0].Units[I];
+    if (U <> nil) and not U.IsDead and (U.UnitType = utRecruit) and (U.InHouse = aHouse) then
+      Inc(Result);
+  end;
+end;
+
+
+{ TKMTest_RecruitsBase }
+procedure TKMTest_RecruitsBase.SetUpScene(aRecruitsCnt: Integer; aAddSchool: Boolean);
+begin
+  gGameApp.NewEmptyMap(32, 32);
+
+  var barracks := TKMHouseBarracks(gHands[0].AddHouse(htBarracks, BARRACKS_LOC.X, BARRACKS_LOC.Y, False));
+  fBarracksUID := barracks.UID;
+
+  if aAddSchool then
+    gHands[0].AddHouse(htSchool, SCHOOL_LOC.X, SCHOOL_LOC.Y, False);
+
+  for var I := 0 to aRecruitsCnt - 1 do
+    barracks.CreateRecruitInside(False);
+
+  fError := '';
+end;
+
+
+procedure TKMTest_RecruitsBase.RecordError(const aError: string);
+begin
+  if fError = '' then // Keep the first error only, it is the most informative one
+    fError := aError;
+end;
+
+
+procedure TKMTest_RecruitsBase.CheckRecordedError;
+begin
+  AssertTrue(fError = '', fError);
+end;
+
+
+function TKMTest_RecruitsBase.BarracksExists: Boolean;
+begin
+  Result := GetBarracks(fBarracksUID) <> nil;
+end;
+
+
+function TKMTest_RecruitsBase.ListedRecruitsCnt: Integer;
+begin
+  var barracks := GetBarracks(fBarracksUID);
+  if barracks = nil then
+    Result := 0
+  else
+    Result := barracks.RecruitsCount;
+end;
+
+
+function TKMTest_RecruitsBase.AliveRecruitsCnt: Integer;
+begin
+  Result := 0;
+  for var I := 0 to gHands[0].Units.Count - 1 do
+  begin
+    var U := gHands[0].Units[I];
+    if (U <> nil) and not U.IsDead and (U.UnitType = utRecruit) then
+      Inc(Result);
+  end;
+end;
+
+
+function TKMTest_RecruitsBase.RecruitObjectsCnt: Integer;
+begin
+  Result := 0;
+  for var I := 0 to gHands[0].Units.Count - 1 do
+  begin
+    var U := gHands[0].Units[I];
+    if (U <> nil) and (U.UnitType = utRecruit) then
+      Inc(Result);
+  end;
+end;
+
+
+function TKMTest_RecruitsBase.CheckNoPhantoms(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  var barracks := GetBarracks(fBarracksUID);
+  if barracks = nil then Exit; // Nothing to check anymore
+
+  var listed := barracks.RecruitsCount;
+  var actual := RecruitsInHouseCnt(barracks);
+
+  Result := listed <= actual;
+  if not Result then
+    RecordError(Format('Tick %d: barracks lists %d recruit(s), while only %d recruit(s) are actually inside it',
+                       [aTick, listed, actual]));
+end;
+
+
+{ TKMTest_Recruit_Dismiss }
+procedure TKMTest_Recruit_Dismiss.SetUp;
+begin
+  fDuration := 2400;
+  SetUpScene(1, True);
+
+  fDismissStarted := False;
+end;
+
+
+function TKMTest_Recruit_Dismiss.DoTick(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  if aTick < SETTLE_TICKS then Exit;
+
+  if aTick = SETTLE_TICKS then
+  begin
+    var U := FindRecruit;
+    if (U = nil) or (U.InHouse <> GetBarracks(fBarracksUID)) or (ListedRecruitsCnt <> 1) then
+    begin
+      RecordError('Test scene is broken: there should be exactly 1 recruit inside the barracks');
+      Exit(False);
+    end;
+
+    U.Dismiss;
+
+    // Dismiss can not even start for a unit inside a house: TKMTaskDismiss.FindNewSchool asks for
+    // a route from the unit position, which is an unwalkable house tile (unlike TKMHand.FindInn,
+    // which asks from the tile below the entrance). Then the recruit must be left alone
+    fDismissStarted := U.IsDismissing;
+    Result := fDismissStarted;
+    Exit;
+  end;
+
+  if not CheckNoPhantoms(aTick) then
+    Exit(False);
+
+  // Keep running while the dismissed recruit is still around
+  Result := AliveRecruitsCnt > 0;
+end;
+
+
+procedure TKMTest_Recruit_Dismiss.CheckResult;
+begin
+  CheckRecordedError;
+
+  if fDismissStarted then
+  begin
+    AssertEquals(0, AliveRecruitsCnt, 'Recruit should have been dismissed');
+    AssertEquals(0, ListedRecruitsCnt, 'Dismissed recruit should be unregistered from the barracks');
+  end
+  else
+  begin
+    AssertEquals(1, AliveRecruitsCnt, 'Recruit should be left alone when the dismiss could not even start');
+    AssertEquals(1, ListedRecruitsCnt, 'Barracks should still list the recruit');
+  end;
+end;
+
+
+class function TKMTest_Recruit_Dismiss.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBarracks, tcRecruit, tcSchool];
+end;
+
+
+class function TKMTest_Recruit_Dismiss.TestDescription: string;
+begin
+  Result := 'Dismissing a recruit who sits inside the barracks must either not start at all or unregister him from the barracks.';
+end;
+
+
+{ TKMTest_Recruit_HomeLostWhileInside }
+procedure TKMTest_Recruit_HomeLostWhileInside.SetUp;
+begin
+  fDuration := 1200;
+  SetUpScene(1, False);
+
+  var inn := gHands[0].AddHouse(htInn, INN_LOC.X, INN_LOC.Y, False);
+  inn.WareAddToIn(wtBread, 3); // Otherwise the Inn is not worth going to
+
+  fStage := 0;
+  fStageTick := 0;
+end;
+
+
+function TKMTest_Recruit_HomeLostWhileInside.DoTick(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  var U := FindRecruit;
+  if U = nil then
+  begin
+    RecordError(Format('Tick %d: recruit is gone, while he was only supposed to stay inside the barracks', [aTick]));
+    Exit(False);
+  end;
+
+  if not CheckNoPhantoms(aTick) then
+    Exit(False);
+
+  case fStage of
+    0:  if aTick >= SETTLE_TICKS then
+        begin
+          U.Condition := UNIT_MIN_CONDITION - 1; // He will take the Inn and a TKMTaskGoEat
+          fStage := 1;
+        end;
+    1:  if U.Task <> nil then // Got the eating task, but it did not start walking him out yet
+        begin
+          var barracks := GetBarracks(fBarracksUID);
+          if barracks = nil then
+          begin
+            RecordError(Format('Tick %d: barracks are gone', [aTick]));
+            Exit(False);
+          end;
+
+          // Barracks stops accepting recruits: that clears his Home, while he stays inside and listed
+          barracks.ToggleAcceptRecruits;
+          // And the Inn is gone, so the eating task ends before he steps out of the barracks
+          gHands[0].RemHouse(INN_LOC, True);
+
+          fStage := 2;
+          fStageTick := aTick;
+        end;
+    2:  if aTick > fStageTick + 200 then // Let him try to do whatever he wants with no Home
+        begin
+          fStage := 3;
+          Exit(False);
+        end;
+  end;
+end;
+
+
+procedure TKMTest_Recruit_HomeLostWhileInside.CheckResult;
+begin
+  CheckRecordedError;
+  AssertTrue(fStage = 3, 'Recruit was expected to get an eating task and then lose both the Inn and his Home');
+
+  var U := FindRecruit;
+  AssertTrue(U <> nil, 'Recruit should be alive');
+  AssertTrue(U.InHouse = GetBarracks(fBarracksUID), 'Recruit should still be inside the barracks');
+  AssertEquals(1, ListedRecruitsCnt, 'Barracks should list exactly 1 recruit');
+end;
+
+
+class function TKMTest_Recruit_HomeLostWhileInside.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBarracks, tcRecruit, tcInn, tcHunger];
+end;
+
+
+class function TKMTest_Recruit_HomeLostWhileInside.TestDescription: string;
+begin
+  Result := 'Recruit who lost his Home while sitting inside the barracks should stay registered there exactly once.';
+end;
+
+
+{ TKMTest_Recruit_HungryCycle }
+procedure TKMTest_Recruit_HungryCycle.SetUp;
+begin
+  fDuration := 1200;
+  SetUpScene(1, False);
+
+  fStage := 0;
+end;
+
+
+function TKMTest_Recruit_HungryCycle.DoTick(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  var U := FindRecruit;
+  if U = nil then
+  begin
+    RecordError(Format('Tick %d: recruit is gone, while he was only supposed to show that he is hungry', [aTick]));
+    Exit(False);
+  end;
+
+  if not CheckNoPhantoms(aTick) then
+    Exit(False);
+
+  case fStage of
+    0:  if aTick >= SETTLE_TICKS then
+        begin
+          // There is no Inn on the map, hence he will go out of the barracks to show that he is hungry
+          U.Condition := UNIT_MIN_CONDITION - 1;
+          fStage := 1;
+        end;
+    1:  if U.Visible then // Stepped out of the barracks
+          fStage := 2;
+    2:  if not U.Visible then
+        begin
+          // Got back inside. Stop right here: he is hungry still, so he would go out again,
+          // and then the barracks list is allowed to be empty
+          fStage := 3;
+          Exit(False);
+        end;
+  end;
+end;
+
+
+procedure TKMTest_Recruit_HungryCycle.CheckResult;
+begin
+  CheckRecordedError;
+  AssertTrue(fStage = 3, 'Recruit should have gone out to show that he is hungry and got back inside');
+
+  var U := FindRecruit;
+  AssertTrue(U <> nil, 'Recruit should be alive');
+  AssertTrue(U.InHouse = GetBarracks(fBarracksUID), 'Recruit should be back inside the barracks');
+  AssertEquals(1, ListedRecruitsCnt, 'Barracks should list exactly 1 recruit');
+end;
+
+
+class function TKMTest_Recruit_HungryCycle.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBarracks, tcRecruit, tcHunger];
+end;
+
+
+class function TKMTest_Recruit_HungryCycle.TestDescription: string;
+begin
+  Result := 'Recruit going out of the barracks to show that he is hungry and back should be registered there exactly once.';
+end;
+
+
+{ TKMTest_Recruit_KilledInside }
+procedure TKMTest_Recruit_KilledInside.SetUp;
+begin
+  fDuration := 1200;
+  SetUpScene(1, False);
+end;
+
+
+function TKMTest_Recruit_KilledInside.DoTick(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  if aTick < SETTLE_TICKS then Exit;
+
+  if aTick = SETTLE_TICKS then
+  begin
+    var U := FindRecruit;
+    if (U = nil) or (U.InHouse <> GetBarracks(fBarracksUID)) then
+    begin
+      RecordError('Test scene is broken: there should be a recruit inside the barracks');
+      Exit(False);
+    end;
+
+    U.Kill(HAND_NONE, True, False);
+    Exit;
+  end;
+
+  if not CheckNoPhantoms(aTick) then
+    Exit(False);
+
+  // Keep running while the dying recruit is still around
+  Result := AliveRecruitsCnt > 0;
+end;
+
+
+procedure TKMTest_Recruit_KilledInside.CheckResult;
+begin
+  CheckRecordedError;
+  AssertEquals(0, AliveRecruitsCnt, 'Recruit should be dead');
+  AssertEquals(0, ListedRecruitsCnt, 'Killed recruit should be unregistered from the barracks');
+end;
+
+
+class function TKMTest_Recruit_KilledInside.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBarracks, tcRecruit];
+end;
+
+
+class function TKMTest_Recruit_KilledInside.TestDescription: string;
+begin
+  Result := 'Killing a recruit inside the barracks should unregister him from the barracks recruits list.';
+end;
+
+
+{ TKMTest_Recruit_ListOwnsPointer }
+procedure TKMTest_Recruit_ListOwnsPointer.SetUp;
+begin
+  fDuration := 600;
+  SetUpScene(1, False);
+
+  fEquipTick := 0;
+end;
+
+
+function TKMTest_Recruit_ListOwnsPointer.DoTick(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  if aTick < SETTLE_TICKS then Exit;
+
+  if aTick = SETTLE_TICKS then
+  begin
+    var U := FindRecruit;
+    var barracks := GetBarracks(fBarracksUID);
+    if (U = nil) or (barracks = nil) or (U.InHouse <> barracks) then
+    begin
+      RecordError('Test scene is broken: there should be a recruit inside the barracks');
+      Exit(False);
+    end;
+
+    if U.PointerCount = 0 then
+      RecordError(Format('Recruit inside the barracks is referenced by nobody (PointerCount = %d), ' +
+                         'so the barracks recruits list is a raw pointer that can dangle', [U.PointerCount]));
+
+    // Equip a warrior out of him: that kills the recruit and unregisters him from the barracks
+    for var W := WARFARE_MIN to WARFARE_MAX do
+      barracks.WareAddToIn(W, 1);
+
+    if barracks.Equip(utMilitia, 1) <> 1 then
+    begin
+      RecordError('Test scene is broken: a militia was expected to be equipped');
+      Exit(False);
+    end;
+
+    fEquipTick := aTick;
+    Exit;
+  end;
+
+  if not CheckNoPhantoms(aTick) then
+    Exit(False);
+
+  // The equipped recruit is not referenced by anyone anymore, so he must be freed by now.
+  // If the reference taken by the barracks list is never released, he would stay forever
+  Result := aTick < fEquipTick + 100;
+end;
+
+
+procedure TKMTest_Recruit_ListOwnsPointer.CheckResult;
+begin
+  CheckRecordedError;
+  AssertEquals(0, ListedRecruitsCnt, 'Equipped recruit should be unregistered from the barracks');
+  AssertEquals(0, RecruitObjectsCnt, 'Equipped recruit object should be freed, otherwise his pointer was never released');
+end;
+
+
+class function TKMTest_Recruit_ListOwnsPointer.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBarracks, tcRecruit, tcMilitia];
+end;
+
+
+class function TKMTest_Recruit_ListOwnsPointer.TestDescription: string;
+begin
+  Result := 'Barracks recruits list should own a counted reference to every recruit it lists, and release it on unregister.';
+end;
+
+
+{ TKMTest_Recruit_BarracksDemolished }
+procedure TKMTest_Recruit_BarracksDemolished.SetUp;
+begin
+  fDuration := 600;
+  SetUpScene(2, False);
+end;
+
+
+function TKMTest_Recruit_BarracksDemolished.DoTick(aTick: Cardinal): Boolean;
+begin
+  Result := True;
+
+  if not CheckNoPhantoms(aTick) then
+    Exit(False);
+
+  if aTick < SETTLE_TICKS then Exit;
+
+  if aTick = SETTLE_TICKS then
+  begin
+    if ListedRecruitsCnt <> 2 then
+    begin
+      RecordError('Test scene is broken: there should be 2 recruits inside the barracks');
+      Exit(False);
+    end;
+
+    gHands[0].RemHouse(BARRACKS_LOC, True);
+    Exit;
+  end;
+
+  if BarracksExists then
+  begin
+    RecordError(Format('Tick %d: barracks should have been demolished', [aTick]));
+    Exit(False);
+  end;
+
+  // Give the recruits some time to be placed outside of the demolished barracks
+  Result := aTick < SETTLE_TICKS + 100;
+end;
+
+
+procedure TKMTest_Recruit_BarracksDemolished.CheckResult;
+begin
+  CheckRecordedError;
+  AssertEquals(2, AliveRecruitsCnt, 'Both recruits should survive the demolition');
+  AssertEquals(2, RecruitsInHouseCnt(nil), 'Both recruits should be placed outside of the demolished barracks');
+end;
+
+
+class function TKMTest_Recruit_BarracksDemolished.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBarracks, tcRecruit];
+end;
+
+
+class function TKMTest_Recruit_BarracksDemolished.TestDescription: string;
+begin
+  Result := 'Recruits of a demolished barracks should be placed outside of it and survive.';
+end;
+
+
+initialization
+  RegisterTest(TKMTest_Recruit_Dismiss);
+  RegisterTest(TKMTest_Recruit_HomeLostWhileInside);
+  RegisterTest(TKMTest_Recruit_HungryCycle);
+  RegisterTest(TKMTest_Recruit_KilledInside);
+  RegisterTest(TKMTest_Recruit_ListOwnsPointer);
+  RegisterTest(TKMTest_Recruit_BarracksDemolished);
+end.

--- a/Utils/Testing_GameTests/Testing_GameTests.dpr
+++ b/Utils/Testing_GameTests/Testing_GameTests.dpr
@@ -28,6 +28,7 @@ uses
   KM_Test_Sawmill in 'KM_Test_Sawmill.pas',
   KM_Test_Sawmill_DeliveryIn in 'KM_Test_Sawmill_DeliveryIn.pas',
   KM_Test_Sawmill_DeliveryOut in 'KM_Test_Sawmill_DeliveryOut.pas',
+  KM_Test_Recruits in 'KM_Test_Recruits.pas',
   KM_Test_Stone in 'KM_Test_Stone.pas',
   KM_Test_Woodcutter_Chop in 'KM_Test_Woodcutter_Chop.pas',
   KM_Test_Woodcutter_Plant in 'KM_Test_Woodcutter_Plant.pas',
@@ -47,6 +48,13 @@ var
 
 begin
   Application.Initialize;
+  Application.ShowMainForm := False; // Form is shown by RunFromCmdLine / Application.Run itself
   Application.CreateForm(TForm2, Form2);
-  Application.Run;
+
+  // Batch mode for the command line, see TForm2.RunFromCmdLine
+  if not Form2.RunFromCmdLine then
+  begin
+    Application.ShowMainForm := True;
+    Application.Run;
+  end;
 end.

--- a/Utils/Testing_GameTests/Testing_GameTests.dproj
+++ b/Utils/Testing_GameTests/Testing_GameTests.dproj
@@ -150,6 +150,7 @@
         <DCCReference Include="KM_Test_Sawmill.pas"/>
         <DCCReference Include="KM_Test_Sawmill_DeliveryIn.pas"/>
         <DCCReference Include="KM_Test_Sawmill_DeliveryOut.pas"/>
+        <DCCReference Include="KM_Test_Recruits.pas"/>
         <DCCReference Include="KM_Test_Stone.pas"/>
         <DCCReference Include="KM_Test_Woodcutter_Chop.pas"/>
         <DCCReference Include="KM_Test_Woodcutter_Plant.pas"/>

--- a/Utils/Testing_GameTests/Unit1.pas
+++ b/Utils/Testing_GameTests/Unit1.pas
@@ -46,9 +46,11 @@ type
     procedure RefreshTestList;
     function IsStopped: Boolean;
     procedure HandleProgress(const aValue: string);
-    procedure EnsureResourcesLoaded;
+    procedure EnsureResourcesLoaded(aBlind: Boolean = False);
     procedure RefreshTagList;
     procedure RunTest(aClass: TKMTestClass; aSeed: Integer);
+  public
+    function RunFromCmdLine: Boolean;
   end;
 
 
@@ -283,26 +285,160 @@ begin
 end;
 
 
-procedure TForm2.EnsureResourcesLoaded;
+procedure TForm2.EnsureResourcesLoaded(aBlind: Boolean = False);
 var
   tgtWidth, tgtHeight: Word;
+  renderArea: TKMRenderControl;
 begin
   if gGameApp <> nil then Exit;
 
-  if fRenderArea = nil then
+  // Blind mode needs no OpenGL context and no window, hence the app could be run from the command line.
+  // SKIP_RENDER must be set before the resources are loaded, it also skips loading of the sprites
+  if aBlind then
+  begin
+    SKIP_RENDER := True;
+    renderArea := nil;
+  end
+  else
+    renderArea := fRenderArea;
+
+  if renderArea = nil then
   begin
     tgtWidth := 1024;
     tgtHeight := 768;
   end else
   begin
-    tgtWidth := fRenderArea.Width;
-    tgtHeight := fRenderArea.Height;
+    tgtWidth := renderArea.Width;
+    tgtHeight := renderArea.Height;
   end;
 
-  gGameApp := TKMGameApp.Create(fRenderArea, tgtWidth, tgtHeight, False, nil, nil, nil, True);
+  gGameApp := TKMGameApp.Create(renderArea, tgtWidth, tgtHeight, False, nil, nil, nil, True);
   gGameSettings.Autosave := False;
   gGameSettings.SaveCheckpoints := False;
   gGameApp.PreloadGameResources;
+end;
+
+
+// Batch mode, allows to run tests without any user interaction:
+//   Testing_GameTests.exe --run-all [--seed=N] [--cycles=N] [--windowed] [--out=<file>]
+//   Testing_GameTests.exe --run=Recruit
+// --run filter is a case insensitive substring of the test class name.
+// Results are written into the --out file, ExitCode is 0 when everything passed, 1 on any failure
+// and 2 when no test matched the filter.
+// Returns False when there were no known switches, then the app should just show its window as usual
+function TForm2.RunFromCmdLine: Boolean;
+const
+  PRM_RUN_ALL   = '--run-all';
+  PRM_RUN       = '--run=';
+  PRM_SEED      = '--seed=';
+  PRM_CYCLES    = '--cycles=';
+  PRM_OUT       = '--out=';
+  PRM_WINDOWED  = '--windowed';
+var
+  filter, outFile, param: string;
+  seed, cycles, ranCnt, failedCnt: Integer;
+  blind: Boolean;
+  results: TStringList;
+
+  function HasPrefix(const aPrefix: string): Boolean;
+  begin
+    Result := SameText(Copy(param, 1, Length(aPrefix)), aPrefix);
+  end;
+
+  function ValueOf(const aPrefix: string): string;
+  begin
+    Result := Copy(param, Length(aPrefix) + 1, MaxInt);
+  end;
+
+begin
+  Result := False;
+
+  filter := '';
+  seed := seSeed.Value;
+  cycles := 1;
+  blind := True;
+  // .log extension, so that the results are covered by .gitignore
+  outFile := ExtractFilePath(ParamStr(0)) + 'Testing_GameTests_results.log';
+
+  for var I := 1 to ParamCount do
+  begin
+    param := ParamStr(I);
+
+    if SameText(param, PRM_RUN_ALL) then
+      Result := True
+    else
+    if HasPrefix(PRM_RUN) then
+    begin
+      Result := True;
+      filter := ValueOf(PRM_RUN);
+    end
+    else
+    if HasPrefix(PRM_SEED) then
+      seed := StrToIntDef(ValueOf(PRM_SEED), seed)
+    else
+    if HasPrefix(PRM_CYCLES) then
+      cycles := StrToIntDef(ValueOf(PRM_CYCLES), cycles)
+    else
+    if HasPrefix(PRM_OUT) then
+      outFile := ValueOf(PRM_OUT)
+    else
+    if SameText(param, PRM_WINDOWED) then
+      blind := False;
+  end;
+
+  if not Result then Exit;
+
+  if not blind then
+    Show; // Render control needs a window to create its OpenGL context
+
+  EnsureResourcesLoaded(blind);
+
+  ranCnt := 0;
+  failedCnt := 0;
+  results := TStringList.Create;
+  try
+    for var C := 0 to cycles - 1 do
+      for var I := 0 to High(gTestList) do
+      begin
+        if (filter <> '') and (Pos(LowerCase(filter), LowerCase(gTestList[I].ClassName)) = 0) then Continue;
+
+        // TKMTest.Run does not guard its SetUp, hence one broken test should not kill the whole batch
+        try
+          RunTest(gTestList[I], seed + C);
+        except
+          on E: Exception do
+          begin
+            fResults.TestResult := trException;
+            fResults.TestMessage := E.ClassName + ': ' + E.Message;
+          end;
+        end;
+        Inc(ranCnt);
+
+        case fResults.TestResult of
+          trSuccess:    results.Add(Format('%-40s SUCCESS      seed %d', [gTestList[I].ClassName, seed + C]));
+          trFailed:     results.Add(Format('%-40s FAILED       seed %d: %s', [gTestList[I].ClassName, seed + C, fResults.TestMessage]));
+          trException:  results.Add(Format('%-40s EXCEPTION    seed %d: %s', [gTestList[I].ClassName, seed + C, fResults.TestMessage]));
+        end;
+
+        if fResults.TestResult <> trSuccess then
+          Inc(failedCnt);
+      end;
+
+    if ranCnt = 0 then
+    begin
+      results.Add(Format('No tests matched filter "%s"', [filter]));
+      ExitCode := 2;
+    end
+    else
+    begin
+      results.Add(Format('Tests run: %d, failed: %d', [ranCnt, failedCnt]));
+      ExitCode := Ord(failedCnt > 0);
+    end;
+
+    results.SaveToFile(outFile);
+  finally
+    results.Free;
+  end;
 end;
 
 

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -15,6 +15,8 @@ type
     fRecruitsList: TList;
     fResourceCount: array [WARFARE_MIN..WARFARE_MAX] of Word;
     procedure SetWareCnt(aWareType: TKMWareType; aValue: Word);
+    procedure RecruitsClear;
+    function TakeFirstRecruit: Pointer;
   public
     MapEdRecruitCount: Word; //Only used by MapEd
     NotAcceptFlag: array [WARFARE_MIN .. WARFARE_MAX] of Boolean;
@@ -59,6 +61,7 @@ implementation
 uses
   Math, Types, SysUtils,
   KM_Entity,
+  KM_Log,
   KM_Hand,
   KM_HandsCollection,
   KM_HandTypes,
@@ -103,11 +106,20 @@ end;
 procedure TKMHouseBarracks.SyncLoad;
 var
   I: Integer;
+  U: TKMUnit;
 begin
   inherited;
 
-  for I := 0 to RecruitsCount - 1 do
-    fRecruitsList.Items[I] := gHands.GetUnitByUID(Integer(fRecruitsList.Items[I]));
+  //Pointer counters are saved along with the units, hence no GetPointer here
+  for I := RecruitsCount - 1 downto 0 do
+  begin
+    U := gHands.GetUnitByUID(Integer(fRecruitsList.Items[I]));
+    if U = nil then
+      //Should never happen, but a nil in the list means a crash in EquipWarrior later on
+      fRecruitsList.Delete(I)
+    else
+      fRecruitsList.Items[I] := U;
+  end;
 end;
 
 
@@ -146,7 +158,7 @@ var
 begin
   //Recruits are no longer under our control so we forget about them (UpdateVisibility will sort it out)
   //Otherwise it can cause crashes while saving under the right conditions when a recruit is then killed.
-  fRecruitsList.Clear;
+  RecruitsClear;
 
   for W := WARFARE_MIN to WARFARE_MAX do
     gHands[Owner].Stats.WareConsumed(W, fResourceCount[W]);
@@ -157,7 +169,9 @@ end;
 
 procedure TKMHouseBarracks.RecruitsAdd(aUnit: Pointer);
 begin
-  fRecruitsList.Add(aUnit);
+  // Take a counted reference, otherwise the recruit could be freed while he is still in our list
+  // (units are freed as soon as their PointerCount is 0) and we would keep a dangling pointer
+  fRecruitsList.Add(TKMUnit(aUnit).GetPointer);
 end;
 
 
@@ -168,8 +182,55 @@ end;
 
 
 procedure TKMHouseBarracks.RecruitsRemove(aUnit: Pointer);
+var
+  U: TKMUnit;
+  I: Integer;
 begin
-  fRecruitsList.Remove(aUnit);
+  I := fRecruitsList.IndexOf(aUnit);
+  if I = -1 then Exit; // Not ours, or he was unregistered already
+
+  U := TKMUnit(fRecruitsList[I]);
+  fRecruitsList.Delete(I);
+  gHands.CleanUpUnitPointer(U);
+end;
+
+
+// Forget all the recruits, releasing the references we were holding
+procedure TKMHouseBarracks.RecruitsClear;
+var
+  U: TKMUnit;
+begin
+  for var I := fRecruitsList.Count - 1 downto 0 do
+  begin
+    U := TKMUnit(fRecruitsList[I]);
+    gHands.CleanUpUnitPointer(U);
+  end;
+
+  fRecruitsList.Clear;
+end;
+
+
+// Unregister the first recruit who is actually sitting inside this very house and return him.
+// The list should never contain anything else, but a stale entry means a crash in KillInHouse,
+// hence such entries are dropped here rather than handed out
+function TKMHouseBarracks.TakeFirstRecruit: Pointer;
+var
+  U: TKMUnit;
+begin
+  Result := nil;
+
+  while (Result = nil) and (fRecruitsList.Count > 0) do
+  begin
+    U := TKMUnit(fRecruitsList[0]);
+    fRecruitsList.Delete(0);
+
+    if (U <> nil) and not U.IsDead and (U is TKMUnitRecruit) and (U.InHouse = Self) then
+      Result := U
+    else
+      gLog.AddTime(Format('TKMHouseBarracks UID %d: dropped an invalid recruit entry', [UID]));
+
+    gHands.CleanUpUnitPointer(U); // Release the reference our list was holding
+  end;
 end;
 
 
@@ -346,11 +407,17 @@ var
   I: Integer;
   troopWareType: TKMWareType;
   soldier: TKMUnitWarrior;
+  recruit: TKMUnitRecruit;
 begin
   Result := nil;
 
   //Make sure we have enough resources to equip a unit
   if not CanEquip(aUnitType) then Exit;
+
+  //Take the recruit before anything else: if the list turns out to have no valid recruit
+  //(should never happen) we must not consume the wares
+  recruit := TKMUnitRecruit(TakeFirstRecruit);
+  if recruit = nil then Exit;
 
   //Take resources
   for I := 1 to 4 do
@@ -364,8 +431,7 @@ begin
   end;
 
   //Special way to kill the Recruit because it is in a house
-  TKMUnitRecruit(fRecruitsList.Items[0]).KillInHouse;
-  fRecruitsList.Delete(0); //Delete first recruit in the list
+  recruit.KillInHouse;
 
   //Make new unit
   soldier := TKMUnitWarrior(gHands[Owner].TrainUnit(aUnitType, Self));

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -433,7 +433,8 @@ end;
 
 procedure TKMCivilUnit.KillInHouse;
 begin
-  Assert(fInHouse <> nil, 'Unit could be silently killed only inside some House');
+  Assert(fInHouse <> nil, Format('Unit %s UID %d could be silently killed only inside some House',
+                                 [gRes.Units[fType].GUIName, UID]));
   //Dispose of current action/task BEFORE we close the unit (action might need to check fPosition if recruit was about to walk out to eat)
   //Normally this isn't required because TTaskDie takes care of it all, but recruits in barracks don't use TaskDie.
   SetAction(nil);
@@ -1401,6 +1402,12 @@ end;
 // Erase everything related to unit status to exclude it from being accessed by anything but the old pointers
 procedure TKMUnit.CloseUnit(aRemoveTileUsage: Boolean = True);
 begin
+  //Barracks keep their own list of the recruits sitting inside, it must not keep a pointer to the
+  //closed unit (f.e. recruit could be killed while he is still inside the barracks).
+  //Normally he is unregistered as soon as he steps out of the doorway, this is the last resort
+  if (fType = utRecruit) and (fInHouse is TKMHouseBarracks) then
+    TKMHouseBarracks(fInHouse).RecruitsRemove(Self);
+
   fHome.SetWorker(nil);
   gHands.CleanUpHousePointer(fHome);
 


### PR DESCRIPTION
## Problem

Issue #300: an assert fires when a warrior is equipped in the barracks.

```
exception message : Unit could be silently killed only inside some House (KM_Units.pas, line 436).

TKMCivilUnit.KillInHouse
TKMHouseBarracks.EquipWarrior
TKMHouseBarracks.Equip
TKMGameInputProcess.ExecCommand
...
TKMGUIGameHouse.House_BarracksUnitChange
```

`EquipWarrior` takes `fRecruitsList[0]` for granted and calls `KillInHouse` on it, and that method asserts the unit is inside some house. So by the time of the click, the entry in the list was no longer a recruit sitting in that barracks.

## Root cause

`fRecruitsList` is the only place in the game that keeps a unit reference without taking a counted one (`TKMHandEntityPointer.GetPointer`), while `TKMUnitsCollection.UpdateState` frees a dead unit as soon as its `PointerCount` reaches 0.

On top of that, nothing unregisters a recruit from the list when he is closed: `RecruitsRemove` used to be called from a single place, `TKMUnitActionGoInOut.WalkOut`, i.e. only when the recruit actually starts stepping out of the doorway. Any path that closes a listed recruit therefore leaves a dangling pointer in the list, `RecruitsCount` keeps counting it (so the UI shows a phantom recruit and the button stays enabled), and `fInHouse` read from the freed object is what the assert reported.

The same class of problem is already acknowledged in `TKMHouseBarracks.Demolish`: *"Otherwise it can cause crashes while saving under the right conditions when a recruit is then killed"* — that comment patched one particular path, the ownership problem stayed.

## What this PR changes

* `RecruitsAdd` / `RecruitsRemove` take and release a counted reference. `RecruitsRemove` is `IndexOf` based and therefore idempotent, so calling it twice is harmless.
* New `RecruitsClear` releases the references before clearing the list, used by `Demolish` — a plain `Clear` would turn the crash into a leak once the references are counted.
* New `TakeFirstRecruit` hands out only a living recruit who really is inside this very house, and drops invalid entries with a log line instead of dereferencing them.
* `EquipWarrior` takes the recruit before consuming the wares, so a broken state no longer costs the player his warfare.
* `TKMUnit.CloseUnit` unregisters the recruit from the barracks as a last resort, so no future path can leave a stale entry behind.
* `TKMHouseBarracks.SyncLoad` drops the entries whose UID could not be resolved instead of leaving `nil` in the list.
* The assert message in `KillInHouse` now carries the unit type and UID, so a future report would tell a living unit from garbage.

## Tests

`Utils/Testing_GameTests/KM_Test_Recruits.pas` adds 6 game tests around the list invariant *"every listed recruit is a living recruit inside that very barracks"*, checked on every tick:

* dismiss a recruit from inside the barracks
* hunger cycle: out of the barracks to show hunger and back in
* kill a recruit inside the barracks
* demolish the barracks with recruits inside
* `Home` lost while inside: the barracks stops accepting recruits while the recruit has an eating task (which clears his `Home`), then the Inn is destroyed before he steps out — the only `Home` / `InHouse` divergence the code itself admits, see the comment in `TKMUnitActionGoInOut.WalkOut`
* the list owns a counted reference to its recruits and releases it when a recruit is equipped

The last one is the test that was red before the fix:

```
TKMTest_Recruit_ListOwnsPointer FAILED: Recruit inside the barracks is referenced by nobody
(PointerCount = 0), so the barracks recruits list is a raw pointer that can dangle
```

All 21 tests (15 existing + 6 new) pass with the fix.

The test runner also gets a batch mode, so that the tests can be run unattended:

```
Testing_GameTests.exe --run-all [--seed=N] [--cycles=N] [--windowed] [--out=<file>]
Testing_GameTests.exe --run=Recruit
```

It runs with a blind render by default (no OpenGL context and no window needed), writes one line per test into a results file and returns a non-zero exit code on any failure. Without switches the app shows its usual window, as before.

## Notes

* The exact in-game sequence that corrupted the list was **not** reproduced. Five scenarios were probed and all of them turned out to be clean, which is explained by `TKMTerrain.RouteCanBeMade` requiring the source tile to be passable: a living listed recruit can hardly leave the barracks other than through `TKMUnitActionGoInOut`, which unregisters him. That leaves the freed-object case, which this PR makes structurally impossible rather than papering over.
* Savegame compatibility: unit `PointerCount` is part of the save, and the counted reference taken by the list changes it, so saves made with the same revision *before* this change would fail in `ReleasePointer`. A revision bump covers that; saves from other revisions are rejected by `TKMGameInfo` anyway.
* Side finding, not addressed here: dismiss silently does nothing for a unit inside a house, because `TKMTaskDismiss.FindNewSchool` builds the route from `fUnit.Position` — an unwalkable house tile — unlike `TKMHand.FindInn`, which adjusts to the tile below the entrance. `TKMTest_Recruit_Dismiss` documents the current behaviour and already covers both branches, so enabling in-house dismiss later would be guarded by it.

Fixes #300
