### PR TITLE
Add AGENTS.md and rules for how an AI agent should work here

### DIFF
--- a/.ai/rules/agent-rules.md
+++ b/.ai/rules/agent-rules.md
@@ -35,6 +35,27 @@ the fix, and the check to run before opening a pull request - is in `workflow.md
 - Update all affected files consistently.
 - Do not introduce new bugs while refactoring.
 
+## What review keeps sending back
+
+Collected from review notes on AI-written changes to this repository. None of these are matters of
+taste; each one has cost a review round.
+
+- **Do not comment what the code already says.** A line that restates the statement below it gets
+  deleted. Comments are for why, and for what is not visible - see `comments.md`.
+- **Do not carry unrelated changes.** A readability tidy-up noticed while fixing a bug does not
+  belong in that bug's diff, however small. It is its own change or it is nothing.
+- **Take the simpler place.** When a guard in one method and one line in a constructor solve the
+  same problem, it is the constructor. Look for the fix that removes the condition rather than
+  the one that handles it.
+- **Put the change where the responsibility is.** If an object needs to tell another object
+  something, let it tell it; do not route the news through a third party that then reaches back
+  into the first. There is usually a precedent already - find the object that does the same thing
+  and follow it.
+- **Name things so the line reads on its own**, and prefer the existing name in the codebase over
+  a new synonym.
+- **When you disagree with a review note, say so and why.** Applying half of it silently is worse
+  than either doing it or arguing against it.
+
 ## Communication
 
 - Be direct and technical in your responses.

--- a/.ai/rules/agent-rules.md
+++ b/.ai/rules/agent-rules.md
@@ -19,6 +19,9 @@ These rules define how AI coding agents should behave when working on this proje
 3. **Implement:** Make precise, targeted changes following project conventions.
 4. **Verify:** Ensure the code compiles mentally (check types, method signatures, etc.).
 
+This is the per-task loop. The process around it - issues, branch naming, when tests come before
+the fix, and the check to run before opening a pull request - is in `workflow.md`.
+
 ## When Adding New Features
 
 - Consider savegame serialization immediately when adding new gameplay fields.

--- a/.ai/rules/project-rules.md
+++ b/.ai/rules/project-rules.md
@@ -23,9 +23,13 @@ When unsure, treat code as gameplay simulation code.
 
 - Gameplay simulation logic must remain deterministic.
 - Do not change savegame/replay/network determinism without explicit approval.
-- The game must use its own deterministic RNG, accessible via the game engine RNG (KaMRandom family), for all gameplay simulation logic.
+- The game must use its own deterministic RNG for all gameplay simulation logic. It lives in `KM_CommonUtils` as `KaMRandom` and its variants (`KaMRandomI2`, `KaMRandomS1`, `KaMRandomS2`, ...), seeded by `SetKaMSeed`. There is no `gRandom` global.
+- Every gameplay RNG call passes the calling method as a label under the RNG spy define, so that a desync can be traced back to the exact call site. Keep this up in new code:
+  ```pascal
+  SetActionStay(20 + KaMRandom(10{$IFDEF DBG_RNG_SPY}, 'TKMTaskGoOutShowHungry.Execute'{$ENDIF}), uaWalk);
+  ```
 - System random is only allowed for non-gameplay things.
-- Gameplay RNG (KaMRandom family) should not be used for non-gameplay things.
+- The gameplay RNG should not be used for non-gameplay things.
 - Gameplay should behave exactly the same regardless of GFX and SFX settings (even in headless mode or without a soundcard detected).
 - Gameplay simulation must not rely on unordered or unspecified execution order. All ordering that can affect gameplay must be explicit and deterministic.
 - Gameplay simulation must not depend on memory addresses, pointer values, object allocation order, hash randomization, container bucket order, or unstable sorting.
@@ -38,7 +42,7 @@ When unsure, treat code as gameplay simulation code.
 
 - Players input during gameplay should go through GameInputProcess, so that it can be recorded for the Replays and relayed to other players in Multiplayer.
 - `GameInputProcess` should be the single entry point for all gameplay input.
-- AI planning and action selection are gameplay simulation logic, so they must be deterministic, use the game engine RNG (KaMRandom family) only, serialize all relevant state.
+- AI planning and action selection are gameplay simulation logic, so they must be deterministic, use the gameplay RNG only, serialize all relevant state.
 - It is not needed to route AI player-equivalent commands through `GameInputProcess`, since AI behavior is expected to be fully deterministic.
 - Map Editor is often allowed to edit gameplay elements state directly, for simplicity. It is important to guard those places from being used in Gameplay by accident.
 - Debug, logging, metrics, assertions, or diagnostics must not mutate gameplay state.
@@ -71,24 +75,33 @@ When unsure, treat code as gameplay simulation code.
 
 ### How serialization is written
 
-Every class that needs to be serialized implements the same three methods:
+Every serializable class implements the same three steps, and they must stay symmetrical:
 
-- `Save(SaveStream)` writes the state into the provided stream. References to other entities are replaced with their UIDs.
-- `Load(LoadStream)` reads the state back in exactly the same order. References to other entities are read as raw UIDs into the pointer fields at this point - they are not valid objects yet.
-- `SyncLoad` performed after everything is loaded by the game. Now those raw UIDs get converted into real references, using locators in gHands (`gHands.GetUnitByUID` / `gHands.GetHouseByUID` / `gHands.GetGroupByUID`).
+- `Save(SaveStream)` writes the state.
+- `Load(LoadStream)` reads it back in exactly the same order. References to other entities are
+  read as raw UIDs into the pointer fields at this point - they are not valid objects yet.
+- `SyncLoad` converts those UIDs back into real references, once every entity exists:
+  `gHands.GetUnitByUID` / `gHands.GetHouseByUID` / `gHands.GetGroupByUID`.
 
-`Save` and `Load` are self-checking, they write and read markers (`SaveStream.PlaceMarker('Name')` / `LoadStream.CheckMarker('Name')`). We place a marker at the start of every `Save`, so that a mismatch between Save and Load is reported where it happened rather than as garbage data much later.
+Streams are self-checking: `SaveStream.PlaceMarker('Name')` writes a marker that
+`LoadStream.CheckMarker('Name')` verifies on load. Place one at the start of every block, so a
+mismatch is reported where it happened rather than as garbage data much later.
 
 ## Entity pointers and lifetime
 
-Units, houses and groups use custom reference counting - so that an entity is not freed while some other object still points at it.
+Units, houses and groups are reference counted, but not by the compiler - the counting is
+explicit and exists so that an entity is not freed while some other object still points at it.
 
 - `GetPointer` returns the entity and increments its counter; `ReleasePointer` decrements it.
-- `TKMUnitsCollection` / `TKMHousesCollection` free an entity only once it is both killed or destroyed **and** its `PointerCount` reaches zero. Until then the object stays available
-  with `IsDestroyed` / `IsDead` set, so callers must check those flags rather than assume that a non-nil reference means a live entity.
-- Release through `gHands.CleanUpUnitPointer` / `CleanUpHousePointer` / `CleanUpGroupPointer`, which releases and nils the field in one step.
-- A field that stores an entity for longer than the current call, must hold a counted reference. A local variable used within one method does not.
-  
+- `TKMUnitsCollection` / `TKMHousesCollection` free an entity only once it is both dead or
+  destroyed **and** its `PointerCount` has dropped to zero. Until then the object stays alive
+  with `IsDestroyed` / `IsDead` set, so callers must check those flags rather than assume that
+  a non-nil reference means a live entity.
+- Release through `gHands.CleanUpUnitPointer` / `CleanUpHousePointer` / `CleanUpGroupPointer`,
+  which release and nil the field in one step.
+- A field that stores an entity for longer than the current call must hold a counted reference.
+  A local variable used within one method does not.
+
 ## Common Sources of Hard-to-Track Bugs & Mitigations
 
 ### Serialization & State Management
@@ -104,8 +117,8 @@ Units, houses and groups use custom reference counting - so that an entity is no
   - *Rule:* Maintain strict command sequencing and implement robust catch-up/resync logic for disconnected players.
 
 ### Randomness & Hidden Dependencies
-- **Silent RNG consumption:** Skipping the game engine RNG (KaMRandom family) calls (e.g., when sound is off) desynchronizes the RNG sequence for subsequent gameplay events.
-  - *Rule:* Always consume the game engine RNG (KaMRandom family) in the exact same order, regardless of GFX/SFX settings or visual/audio output.
+- **Silent RNG consumption:** Skipping gameplay RNG calls (e.g., when sound is off) desynchronizes the RNG sequence for subsequent gameplay events.
+  - *Rule:* Always consume the gameplay RNG in the exact same order, regardless of GFX/SFX settings or visual/audio output.
 - **Camera & presentation bleed:** Relying on camera position, frame time, or render state to trigger simulation updates (e.g., fog-of-war chunk loading) causes machine-dependent behavior.
   - *Rule:* Decouple simulation triggers from presentation state. Use fixed tick-based or event-driven updates independent of the viewport.
 

--- a/.ai/rules/project.md
+++ b/.ai/rules/project.md
@@ -23,7 +23,7 @@
 
 ## Technology
 
-- Main language: Delphi (10 through 13) / Lazarus (FPC). Object Pascal.
+- Main language: Delphi (11 to 13) / Lazarus (FPC). Object Pascal.
 - Target platform for main game: 32-bit Windows.
 - Target platform for auxiliary tools (e.g. Dedicated Server): Linux x86, Linux x64, Windows.
 - Graphics & Rendering: OpenGL with custom engine.

--- a/.ai/rules/pull-request.md
+++ b/.ai/rules/pull-request.md
@@ -1,0 +1,101 @@
+# Pull Request Description
+
+The pull request body is where a reviewer decides whether to trust the change and where to spend
+attention. It should say what to look at, what was already checked and what was not - it should
+not restate the diff, which the reviewer can read.
+
+Write it in English, like the rest of the repository.
+
+## Link the issue without closing it
+
+```
+Related to #<issue>
+```
+
+Use `Closes` or `Fixes` only when merging really should close the issue. A change that removes one
+crash path without finding the cause, or that covers part of a problem, is `Related to` - closing
+the issue in that case buries the part nobody solved.
+
+## Template
+
+```markdown
+Related to #<issue>
+
+## Summary
+
+One paragraph: what changed and why.
+
+- What the issue asked for:
+- What this delivers:
+- Deliberately left out:
+
+## Review intent
+
+- Look here first:
+- Risky:
+- Mechanical / low risk:
+- Worth challenging:
+
+## Implementation notes
+
+- Decisions and the reasoning behind them:
+- Trade-offs:
+- Follow-up work, with issue links if any were opened:
+
+## Determinism and savegames
+
+- Gameplay simulation touched, and on which side of the boundary:
+- New gameplay fields, and whether they are serialized:
+- Savegame, replay or multiplayer sync affected:
+
+## Verification
+
+- Built:
+- Tests run, and what they reported:
+- Manual check, with the steps taken:
+- Not run or blocked, and why:
+
+## Risks and open questions
+
+-
+```
+
+## What each section is for
+
+**Summary.** The three bullets matter more than the paragraph. "What the issue asked for" next to
+"what this delivers" is what lets a reviewer see a mismatch without reading the whole diff, and
+**deliberately left out** is the one a reviewer will otherwise ask about after they have already
+read everything. Say up front that the root cause was not found, that a case is not covered, that
+a fixture is missing.
+
+**Review intent.** Reviewer attention is the scarce resource. Point it at the parts that can be
+wrong, and say plainly which parts are renames, formatting or mechanical follow-through so they
+are not read line by line. "Worth challenging" is not modesty - if a decision could reasonably
+have gone the other way, name it, because that is where a review earns its keep.
+
+This section is also where anything the issue did not ask for gets declared. A reviewer should
+never discover an unexplained rename, a refactor or a moved file in the diff, least of all in a
+force-push. Declaring it is not optional; if it cannot be justified in a sentence, take it out and
+put it in its own issue.
+
+**Implementation notes.** Why, not what. If an approach was chosen over an obvious alternative,
+the reason belongs here rather than in the reviewer's head.
+
+**Determinism and savegames.** These are the two things in this engine that break quietly and
+expensively, so they are stated explicitly every time - see `project-rules.md`. If a row does not
+apply, say why it cannot apply to this diff. A bare `N/A` is not an answer.
+
+**Verification.** State what actually ran and what it said. Never write that the build is clean or
+the tests pass without a real build and a real run behind it - and remember there is no
+command-line build on a Community Edition machine, so "built" often means asking someone. Listing
+what was **not** run is as important as listing what was: an unrun check that looks run is worse
+than an admitted gap.
+
+**Risks and open questions.** Cheap to write, and it is where a reviewer can hand back the one
+piece of knowledge the author lacks.
+
+## Keep it in step with the branch
+
+When the branch changes after review has started, say what changed and why in a comment - a
+reviewer who already read the diff has no way to tell a rebase from a rewrite. Answer review
+comments where they were made, and say what changed, not only that you agree.

--- a/.ai/rules/pull-request.md
+++ b/.ai/rules/pull-request.md
@@ -1,101 +1,54 @@
-# Pull Request Description
+# Pull request description
 
-The pull request body is where a reviewer decides whether to trust the change and where to spend
-attention. It should say what to look at, what was already checked and what was not - it should
-not restate the diff, which the reviewer can read.
-
-Write it in English, like the rest of the repository.
-
-## Link the issue without closing it
-
-```
-Related to #<issue>
-```
-
-Use `Closes` or `Fixes` only when merging really should close the issue. A change that removes one
-crash path without finding the cause, or that covers part of a problem, is `Related to` - closing
-the issue in that case buries the part nobody solved.
+Short. The diff says what changed; the description says what a reader cannot get from the diff.
 
 ## Template
 
 ```markdown
+## Title
+
+<!-- TLDR, max 15 words -->
+
+## Description
+
+<!-- One short paragraph: what changed and why. -->
+<!-- TLDR, max 50 words -->
+
+### Critical information that is not in the code
+
+<!-- if needed -->
+<!-- Link to the issue, or describe the situation when there is none. Max 50 words. -->
+
+<!-- Use the non-closing link by default. Use Closes/Fixes only when this pull request closes the issue. -->
 Related to #<issue>
-
-## Summary
-
-One paragraph: what changed and why.
-
-- What the issue asked for:
-- What this delivers:
-- Deliberately left out:
-
-## Review intent
-
-- Look here first:
-- Risky:
-- Mechanical / low risk:
-- Worth challenging:
-
-## Implementation notes
-
-- Decisions and the reasoning behind them:
-- Trade-offs:
-- Follow-up work, with issue links if any were opened:
-
-## Determinism and savegames
-
-- Gameplay simulation touched, and on which side of the boundary:
-- New gameplay fields, and whether they are serialized:
-- Savegame, replay or multiplayer sync affected:
-
-## Verification
-
-- Built:
-- Tests run, and what they reported:
-- Manual check, with the steps taken:
-- Not run or blocked, and why:
-
-## Risks and open questions
-
--
 ```
 
-## What each section is for
+## What each part is for
 
-**Summary.** The three bullets matter more than the paragraph. "What the issue asked for" next to
-"what this delivers" is what lets a reviewer see a mismatch without reading the whole diff, and
-**deliberately left out** is the one a reviewer will otherwise ask about after they have already
-read everything. Say up front that the root cause was not found, that a case is not covered, that
-a fixture is missing.
+**Title** - what was done, not how. It is the line that shows up in the commit list forever.
 
-**Review intent.** Reviewer attention is the scarce resource. Point it at the parts that can be
-wrong, and say plainly which parts are renames, formatting or mechanical follow-through so they
-are not read line by line. "Worth challenging" is not modesty - if a decision could reasonably
-have gone the other way, name it, because that is where a review earns its keep.
+**Description** - one paragraph. If it needs more than that, the change is probably two changes;
+see the split decision in `workflow.md`.
 
-This section is also where anything the issue did not ask for gets declared. A reviewer should
-never discover an unexplained rename, a refactor or a moved file in the diff, least of all in a
-force-push. Declaring it is not optional; if it cannot be justified in a sentence, take it out and
-put it in its own issue.
+**Critical information that is not in the code** - the section that earns its place. A crash log
+from the issue, why the fix is where it is rather than the obvious place, what was tried and did
+not work, which part is a mitigation rather than a cure. Skip it when there is nothing to say.
 
-**Implementation notes.** Why, not what. If an approach was chosen over an obvious alternative,
-the reason belongs here rather than in the reviewer's head.
+**Related to / Closes** - `Related to` by default. `Closes` only when the issue is actually
+finished by this change. A pull request that removes a crash without explaining its cause does not
+close the issue, and saying so is more useful than a green checkmark.
 
-**Determinism and savegames.** These are the two things in this engine that break quietly and
-expensively, so they are stated explicitly every time - see `project-rules.md`. If a row does not
-apply, say why it cannot apply to this diff. A bare `N/A` is not an answer.
+## Two things worth adding when they apply
 
-**Verification.** State what actually ran and what it said. Never write that the build is clean or
-the tests pass without a real build and a real run behind it - and remember there is no
-command-line build on a Community Edition machine, so "built" often means asking someone. Listing
-what was **not** run is as important as listing what was: an unrun check that looks run is worse
-than an admitted gap.
-
-**Risks and open questions.** Cheap to write, and it is where a reviewer can hand back the one
-piece of knowledge the author lacks.
+- **Determinism and savegames.** If the change touches gameplay simulation or anything
+  serialized, say what happens to the savegame format and to replay determinism. These break
+  quietly, and a reviewer cannot see from a diff that you thought about it.
+- **What was verified, and what was not.** Which tests ran and what they reported, over how many
+  seeds. Equally, what you did not run - a multiplayer session, a real savegame from a player.
+  Building here is manual, so "it compiles" is never implied.
 
 ## Keep it in step with the branch
 
-When the branch changes after review has started, say what changed and why in a comment - a
-reviewer who already read the diff has no way to tell a rebase from a rewrite. Answer review
-comments where they were made, and say what changed, not only that you agree.
+If the branch changes shape after review - a rewritten approach, a dropped file, a rebase that
+takes commits with it - update the description too. A description that describes an older version
+of the branch is worse than a short one.

--- a/.ai/rules/testing.md
+++ b/.ai/rules/testing.md
@@ -1,0 +1,89 @@
+# Testing
+
+There are two test projects. They are not interchangeable - pick by what the code under test is,
+and follow the conventions already present in that project.
+
+| Project | Framework | Use it for |
+|---|---|---|
+| `Utils/UnitTests` | DUnit (`TestFramework`) | Pure logic with no game around it: utilities, points, streams, containers |
+| `Utils/Testing_GameTests` | Own harness (`KM_Test.pas`) | Gameplay behaviour, which needs a running game |
+
+Neither project can be built from the command line - see the build note in `project.md`.
+
+## Unit tests (`Utils/UnitTests`)
+
+DUnit, not DUnitX. Do not introduce DUnitX, `[TestFixture]` attributes or a DUnitX runner here.
+
+- One `TTestCase` descendant per unit under test, file named `TestKM_<Unit>.pas`.
+- Test methods go in the `published` section - that is how DUnit discovers them.
+- `SetUp` / `TearDown` are `override`.
+- Register in `initialization` with `RegisterTest(TestKMSomething.Suite);`.
+- The runner is `UnitTests.dpr`, GUI by default and console under `CONSOLE_TESTRUNNER`.
+
+## Game tests (`Utils/Testing_GameTests`)
+
+These run a real game with no user interface at all (see the headless section in
+`project-rules.md`), tick it forward, and check what happened. One class per file.
+
+### Shape of a test
+
+`TKMTest` splits the test along Arrange - Act - Assert, and the split is not optional:
+
+- `SetUp` - **Arrange.** Start the world (`gGameApp.NewGameEmptyMap`), place houses and units,
+  set `fDuration` (the number of ticks to run).
+- `DoTick(aTick)` - **Act.** Called once per tick. Read it as a human sequence: "at tick 30, save
+  the game", "at tick 10, equip a soldier". Returning `False` ends the run early.
+- `CheckResult` - **Assert.** What must be true when the run is over.
+- `TestTags` and `TestDescription` describe the test for the runner. The description states the
+  expected behaviour, not the mechanics.
+- Register in `initialization` with `RegisterTest(TKMTest_Something);`.
+
+Assertions are `AssertTrue` and `AssertEquals` from `KM_Test`. Assert as soon as the answer is
+known - preferably inside `DoTick` - rather than storing values in fields to compare later.
+
+### Rules for writing them
+
+- A test must not know the implementation. Name it after the behaviour, and check the behaviour
+  through the public API. `TKMTest_Recruit_ListOwnsPointer` is a bad name; a test that reads a
+  private counter is a bad test.
+- One behaviour per test. If a test needs two unrelated assertions, it is two tests.
+- No leftovers. Every field, constant and helper in the test has to earn its place - copying the
+  skeleton of another test and leaving its settling delays and lookup helpers in place is worse
+  than writing it from scratch.
+- Do not defer work into fields when a local variable does. If the test built the world itself,
+  the expected values are known by construction and there is nothing to capture beforehand.
+
+### Two traps in the harness
+
+- `SetUp` is called **outside** the `try..except` in `TKMTest.Run`, so a failed assertion there
+  escapes uncaught instead of being reported as a failed test. Keep assertions out of `SetUp`.
+- `CheckResult` is called from a `finally`, so raising in it replaces any exception that `DoTick`
+  was already raising. Do not let a follow-up check hide the original failure.
+
+### File and class naming
+
+Follow the suite: `KM_Test_<Area>_<Aspect>.pas` holding `TKMTest_<Area><Aspect>` - the file
+separates the parts with an underscore, the class concatenates them.
+
+```
+KM_Test_Sawmill_DeliveryIn.pas  ->  TKMTest_SawmillDeliveryIn
+KM_Test_Bakery.pas              ->  TKMTest_Bakery
+```
+
+New test units must be registered in both `Testing_GameTests.dpr` and `Testing_GameTests.dproj`,
+keeping the existing alphabetical order - see `project-layout.md`.
+
+### Running them
+
+```
+Testing_GameTests.exe --run-all [--seed=N] [--cycles=N] [--show-window] [--out=<file>]
+Testing_GameTests.exe --run=Recruit
+```
+
+`--run` filters on a case insensitive substring of the test class name. Results go to the `--out`
+file, by default `Testing_GameTests_results.log` next to the executable. Exit code is `0` when
+everything passed, `1` when something failed and `2` when the filter matched no test.
+
+Tests must be deterministic: the same seed must always give the same result. `--cycles` reruns
+the set with a different seed each time and is the cheapest way to catch a test that only passes
+by luck.

--- a/.ai/rules/testing.md
+++ b/.ai/rules/testing.md
@@ -1,77 +1,100 @@
 # Testing
 
-There are two test projects. They are not interchangeable - pick by what the code under test is,
-and follow the conventions already present in that project.
+Two separate test projects, with different purposes and different frameworks. Pick the one that
+fits and follow what the tests already there do.
 
-| Project | Framework | Use it for |
+| Project | Framework | For |
 |---|---|---|
-| `Utils/UnitTests` | DUnit (`TestFramework`) | Pure logic with no game around it: utilities, points, streams, containers |
-| `Utils/Testing_GameTests` | Own harness (`KM_Test.pas`) | Gameplay behaviour, which needs a running game |
-
-Neither project can be built from the command line - see the build note in `project.md`.
+| `Utils/UnitTests` | DUnit | Pure logic with no game around it: utilities, points, streams, containers |
+| `Utils/Testing_GameTests` | Own harness (`TKMTest`) | Gameplay behaviour, by running a real game and ticking it |
 
 ## Unit tests (`Utils/UnitTests`)
 
-DUnit, not DUnitX. Do not introduce DUnitX, `[TestFixture]` attributes or a DUnitX runner here.
-
-- One `TTestCase` descendant per unit under test, file named `TestKM_<Unit>.pas`.
-- Test methods go in the `published` section - that is how DUnit discovers them.
-- `SetUp` / `TearDown` are `override`.
+- Descend from `TTestCase`, put the test methods under `published`.
 - Register in `initialization` with `RegisterTest(TestKMSomething.Suite);`.
 - The runner is `UnitTests.dpr`, GUI by default and console under `CONSOLE_TESTRUNNER`.
 
 ## Game tests (`Utils/Testing_GameTests`)
 
-These run a real game with no user interface at all (see the headless section in
-`project-rules.md`), tick it forward, and check what happened. One class per file.
+These start a game, tick it forward and check what happened. One class per file.
+
+The game runs with a blind render (`TKMRender` with no render control), not with no render at all:
+`gRender` exists, and so does the gameplay interface. Passing `--show-window` gives it a real
+window instead, which is useful when you want to watch a test.
 
 ### Shape of a test
 
-`TKMTest` splits the test along Arrange - Act - Assert, and the split is not optional:
+```pascal
+TKMTest_SomethingHappens = class(TKMTest)
+private const
+  SOME_LIMIT = 10;
+protected
+  procedure SetUp; override;
+  procedure DoTick(aTick: Cardinal; var aKeepGoing: Boolean); override;
+  procedure CheckResult; override;
+public
+  class function TestTags: TKMTestTagSet; override;
+  class function TestDescription: string; override;
+end;
+```
 
-- `SetUp` - **Arrange.** Start the world (`gGameApp.NewGameEmptyMap`), place houses and units,
-  set `fDuration` (the number of ticks to run).
-- `DoTick(aTick)` - **Act.** Called once per tick. Read it as a human sequence: "at tick 30, save
-  the game", "at tick 10, equip a soldier". Returning `False` ends the run early.
-- `CheckResult` - **Assert.** What must be true when the run is over.
-- `TestTags` and `TestDescription` describe the test for the runner. The description states the
-  expected behaviour, not the mechanics.
+- `SetUp` - build the world: `gGameApp.NewGameEmptyMap`, place houses and units, set `fDuration`
+  (how many ticks to run at most).
+- `DoTick(aTick, aKeepGoing)` - called once per tick. `aKeepGoing` comes in `True`, so only touch
+  it to stop early. Assert here, as soon as the answer is known.
+- `CheckResult` - what must hold once the run is over. May be empty with a comment saying so, if
+  everything was checked as it went.
+- `TearDown` - only if `SetUp` changed a global, to put it back.
 - Register in `initialization` with `RegisterTest(TKMTest_Something);`.
 
-Assertions are `AssertTrue` and `AssertEquals` from `KM_Test`. Assert as soon as the answer is
-known - preferably inside `DoTick` - rather than storing values in fields to compare later.
+Assertions are `AssertTrue` and `AssertEquals` from `KM_Test`.
+
+### Style
+
+Follow `KM_Test_Archers_GoFar.pas`, which is the fullest example in the suite:
+
+- Constants belong in the class as `private const`, not in a unit level `const` block.
+- Helpers that need game types go at unit level in the `implementation` section, above the class
+  methods.
+- Prefer `Continue` guards over one compound condition when walking units or houses.
+- Say what the test builds and when it fails in a comment above the class.
+- The test builds its own map, so `gHands[0].Houses[0]` is enough to reach the house it placed.
+- Write durations as ticks per minute where that reads better: `fDuration := 3 * 600;`.
+- Failure messages should carry the numbers that failed and the tick, so the log is enough to
+  understand what went wrong without a debugger.
 
 ### Rules for writing them
 
-- A test must not know the implementation. Name it after the behaviour, and check the behaviour
-  through the public API. `TKMTest_Recruit_ListOwnsPointer` is a bad name; a test that reads a
-  private counter is a bad test.
-- One behaviour per test. If a test needs two unrelated assertions, it is two tests.
-- No leftovers. Every field, constant and helper in the test has to earn its place - copying the
-  skeleton of another test and leaving its settling delays and lookup helpers in place is worse
-  than writing it from scratch.
-- Do not defer work into fields when a local variable does. If the test built the world itself,
-  the expected values are known by construction and there is nothing to capture beforehand.
+- One behaviour per test.
+- Drive the game, do not reach into internal state to force a situation. A test that assigns a
+  field to set up its scenario is testing the assignment, not the game.
+- Do not tie a test to a tick the game chooses. Anything that follows from walking, eating or
+  pathfinding lands on a different tick for every seed, and the suite is run over several seeds
+  with `--cycles`. Watch for the state instead. Ticks the test itself picks are fine.
+- Keep no more state on the test than the run actually needs. A `Boolean` field that only restates
+  what the current tick or the world already says should not exist.
+- Clean up after a test that changes a global, in `TearDown`.
 
 ### Two traps in the harness
 
-- `SetUp` is called **outside** the `try..except` in `TKMTest.Run`, so a failed assertion there
-  escapes uncaught instead of being reported as a failed test. Keep assertions out of `SetUp`.
-- `CheckResult` is called from a `finally`, so raising in it replaces any exception that `DoTick`
-  was already raising. Do not let a follow-up check hide the original failure.
+- **`SetUp` runs outside the `try` in `Run`.** An exception there escapes as a plain exception, not
+  as a test failure.
+- **`CheckResult` runs from a `finally`.** If it raises while `DoTick` is already raising, its
+  exception replaces the original one and the log shows the wrong cause. Record that a step
+  happened before the step that can fail, not after.
 
-### File and class naming
+### Naming
 
-Follow the suite: `KM_Test_<Area>_<Aspect>.pas` holding `TKMTest_<Area><Aspect>` - the file
-separates the parts with an underscore, the class concatenates them.
+`KM_Test_<Area>_<Aspect>.pas` holding `TKMTest_<Area><Aspect>` - the file separates the parts with
+an underscore, the class runs them together.
 
 ```
 KM_Test_Sawmill_DeliveryIn.pas  ->  TKMTest_SawmillDeliveryIn
 KM_Test_Bakery.pas              ->  TKMTest_Bakery
 ```
 
-New test units must be registered in `Testing_GameTests.dpr`, keeping the existing alphabetical
-order - see `coding-rules.md`.
+New test units go in `Testing_GameTests.dpr`, in the existing alphabetical order - see
+`coding-rules.md`.
 
 ### Running them
 
@@ -80,10 +103,7 @@ Testing_GameTests.exe --run-all [--seed=N] [--cycles=N] [--show-window] [--out=<
 Testing_GameTests.exe --run=Recruit
 ```
 
-`--run` filters on a case insensitive substring of the test class name. Results go to the `--out`
-file, by default `Testing_GameTests_results.log` next to the executable. Exit code is `0` when
-everything passed, `1` when something failed and `2` when the filter matched no test.
-
-Tests must be deterministic: the same seed must always give the same result. `--cycles` reruns
-the set with a different seed each time and is the cheapest way to catch a test that only passes
-by luck.
+`--run` takes a case insensitive substring of the test class name. `--cycles=N` runs the selection
+N times, incrementing the seed each time, which is how a test that only passes on one seed gets
+caught. Results go to `--out`, by default `Testing_GameTests_results.log`. Exit code is 0 when
+everything passed and 1 when something did not.

--- a/.ai/rules/testing.md
+++ b/.ai/rules/testing.md
@@ -70,8 +70,8 @@ KM_Test_Sawmill_DeliveryIn.pas  ->  TKMTest_SawmillDeliveryIn
 KM_Test_Bakery.pas              ->  TKMTest_Bakery
 ```
 
-New test units must be registered in both `Testing_GameTests.dpr` and `Testing_GameTests.dproj`,
-keeping the existing alphabetical order - see `project-layout.md`.
+New test units must be registered in `Testing_GameTests.dpr`, keeping the existing alphabetical
+order - see `coding-rules.md`.
 
 ### Running them
 

--- a/.ai/rules/testing.md
+++ b/.ai/rules/testing.md
@@ -83,6 +83,43 @@ Follow `KM_Test_Archers_GoFar.pas`, which is the fullest example in the suite:
   exception replaces the original one and the log shows the wrong cause. Record that a step
   happened before the step that can fail, not after.
 
+### What review keeps sending back
+
+Every item below is something a reviewer here has already had to say about an AI-written test.
+They cost nothing to get right the first time.
+
+**Do not build scaffolding the test does not need.**
+
+- A helper method that wraps one expression is an overcomplication, not an abstraction. Call the
+  expression.
+- A field that holds a value only to compare it ten lines later in the same method is not state.
+  Compare it where you have it.
+- A unit level `const` block in a test is noise - inline the number. If it genuinely needs a name,
+  because it is the threshold the test is *about*, put it in the class as `private const`, the way
+  `MAX_WALK_DIST` does in `KM_Test_Archers_GoFar`.
+- Drop conditions that cannot be false. Filtering units by `UnitType = utRecruit` inside a
+  barracks says nothing, because nothing else is in there.
+
+**A test has to be worth the world it builds.**
+
+- Do not assert on a fraction of the state and describe it as the whole. A savegame is megabytes;
+  checking a dozen bytes of it and calling the test "the world came back unchanged" claims
+  something it never measured.
+- Aiming at the whole world in one test is not feasible. Pick the one behaviour the test is really
+  about, and let `TestDescription` say exactly that and no more.
+- A game test is about gameplay. If what you are checking is a serialization detail or a utility
+  function, it belongs in `Utils/UnitTests`.
+
+**Readability is a review criterion, not a preference.**
+
+- If a reviewer has to work at following the control flow, simplify it. Where the test picks the
+  moment, drive off `aTick` rather than a state machine of `Boolean` fields.
+- `unitsInside`, not `inside`. A name that needs the surrounding line to be understood is too
+  short.
+- Keep a `Format` call on one line where it fits, and put the tick at the end of the message.
+- Put a comment next to the statement it explains, inside the branch, rather than above the whole
+  block.
+
 ### Naming
 
 `KM_Test_<Area>_<Aspect>.pas` holding `TKMTest_<Area><Aspect>` - the file separates the parts with

--- a/.ai/rules/tools-and-utils.md
+++ b/.ai/rules/tools-and-utils.md
@@ -31,6 +31,8 @@ Tools for running automated game scenarios and balance analysis.
 Dedicated projects for verifying code correctness.
 - **Unit Tests:** `UnitTests` (DUnit-based unit tests for common utilities, classes, and core systems).
 
+How to write and run either of the two test projects is covered in `testing.md`.
+
 ### 4. Server and multiplayer infrastructure
 Tools for managing the online experience and hosting games.
 - **Hosting:** `DedicatedServer` (Target: Windows, Linux x86 and Linux x64).

--- a/.ai/rules/workflow.md
+++ b/.ai/rules/workflow.md
@@ -3,7 +3,7 @@
 How a change gets from an idea to a merged pull request. This is about process; what the code
 itself has to look like is in the other rule files.
 
-## Every change starts from a GitHub issue
+## Every change to the game starts from a GitHub issue
 
 The issue is what the branch is named after and what the pull request closes, and it is where the
 problem is described so that the pull request can stay about the solution. If there is no issue
@@ -14,6 +14,7 @@ for the task yet, open one before starting.
 ```
 feature/<issue>-short-title
 bugfix/<issue>-short-title
+docs/short-title
 ```
 
 The issue number comes first, then a short lowercase kebab-case title - enough to recognise the
@@ -22,7 +23,19 @@ branch in a list, not a summary of the change. As used in the repository:
 ```
 feature/2226-animals-can-block-units
 bugfix/300-barracks-recruits-list
+docs/ai-agent-rules
 ```
+
+`docs/` covers documentation, the agent rules themselves, and build, CI and tooling
+configuration. It is the one prefix that does not need an issue, since there is often nothing to
+describe beyond the change itself - use `docs/<issue>-short-title` when an issue does exist. It is
+also the one prefix that is not split into a test pull request and a fix pull request, because
+there is no behaviour to reproduce.
+
+That exemption is exactly as narrow as it sounds: a change that touches `src/` is a feature or a
+bug fix, whatever else it also does. Infrastructure work on the engine - a new harness capability,
+something made testable - carries an issue and follows the rules for its kind. `docs/` is not a
+way around writing the test first.
 
 ## Bugs: the test comes first, in its own pull request
 

--- a/.ai/rules/workflow.md
+++ b/.ai/rules/workflow.md
@@ -75,9 +75,13 @@ Not a glance over the diff - a fresh pass with the issue open next to it:
 **If anything is off, fix it and run the pass again from the top.** The check is repeated until it
 comes back clean, not performed once and filed away.
 
+What the pull request body itself has to contain - and why `Related to` is the default rather than
+`Closes` - is in `pull-request.md`. The outcome of this check is part of it: the scope bullets and
+the verification section are where it gets written down.
+
 ## Review
 
 Answer review comments where they were made, and say what changed rather than only that you
 agree. When a comment leads to a different change than the one suggested, or when something else
 gets changed along the way, say that in the pull request too - a reviewer should never have to
-discover an unexplained rename in a force-push.
+discover an unexplained rename in a force-push. See `pull-request.md`.

--- a/.ai/rules/workflow.md
+++ b/.ai/rules/workflow.md
@@ -1,87 +1,101 @@
 # Workflow
 
-How a change gets from an idea to a merged pull request. This is about process; what the code
-itself has to look like is in the other rule files.
+The loop to run for a change to this engine. It is about process; what the code has to look like
+is in the other rule files.
 
-## Every change to the game starts from a GitHub issue
+Steps 4 to 8 are a review of your own work, done before anyone else sees it. They are the point of
+this file: the first pass at a change in a codebase this old is usually wrong in a way that is
+cheap to find yourself and expensive to find in review.
 
-The issue is what the branch is named after and what the pull request closes, and it is where the
-problem is described so that the pull request can stay about the solution. If there is no issue
-for the task yet, open one before starting.
+## 1. Get the task
 
-## Branch naming
+From a GitHub issue, or from the chat. Both are normal here - an issue is not a precondition for
+doing work, and plenty of changes never have one.
+
+If there is an issue, read it in full, including any crash log attached to it. A stack trace names
+the exact method and line that failed and is worth more than any amount of guessing.
+
+Write down what the task actually asks for before touching anything, because that sentence is what
+step 4 checks the result against.
+
+## 2. Investigation
+
+Read the code before changing it. Do not assume an API exists - this codebase renames things
+often, and a plausible-looking identifier is frequently the old one.
+
+- Find where the reported behaviour actually comes from, not where it looks like it should.
+- Work out which side of the determinism boundary the code sits on (`project-rules.md`).
+- Check whether the state you are about to rely on is serialized, and how (`project-rules.md`).
+- If an entity reference is involved, check whether it is counted (`project-rules.md`).
+
+State what you verified and what you only assumed. An assumption carried into step 3 unmarked is
+the most expensive thing in this list.
+
+## 3. Implementation
+
+Make the change small and in the style of the code around it.
+
+For a bug, write the reproduction first and watch it fail. A test that has never failed proves
+nothing about the bug - it only proves it passes. If the reproduction cannot be made to fail, the
+cause is not understood yet: go back to step 2 rather than writing a fix that might do nothing.
+
+Reproduction and fix are easier to review as two pull requests, the test first. Say so in the test
+one, so nobody reads a deliberately failing test as broken.
+
+## 4. Review: readiness and design closure
+
+- Does the change do what step 1 wrote down? Not more, not less.
+- Is the cause understood, or only the symptom suppressed? A change that removes a crash without
+  explaining it is a mitigation - say so, and do not close the issue with it.
+- Would a second reader reach the same conclusion from what is in the diff and the description, or
+  only from having been in your head?
+
+## 5. Review: scope escalation and split decision
+
+Anything that crept in beyond step 1 either comes out or is declared.
+
+- Refactoring found on the way: separate pull request, or leave it.
+- A second bug found on the way: its own issue.
+- Renames and moves: name them in the description, so they are not discovered inside a diff.
+
+If the change cannot be described in one sentence without an "and", it is probably two changes.
+
+## 6. Review: implementation discipline
+
+- Naming and formatting (`styleguide.md`), comments that say why rather than what
+  (`comments.md`).
+- Language and compiler rules (`coding-rules.md`), including registering a new unit in the `.dpr`.
+- Determinism: RNG through the `KaMRandom` family with its call site label, no dependency on real
+  time, render state or unordered container iteration (`project-rules.md`).
+- Serialization: any new gameplay field considered for `Save` / `Load` / `SyncLoad`, and the three
+  kept symmetrical (`project-rules.md`).
+- Tests follow the suite's shape (`testing.md`).
+
+## 7. Local verification
+
+Build, then run - and report what actually ran and what it said.
 
 ```
-feature/<issue>-short-title
-bugfix/<issue>-short-title
-docs/short-title
+Testing_GameTests.exe --run-all
 ```
 
-The issue number comes first, then a short lowercase kebab-case title - enough to recognise the
-branch in a list, not a summary of the change. As used in the repository:
+- For a bug, run the reproduction both with and without the fix. Red then green is the evidence;
+  green alone is not.
+- Run the affected tests over several seeds with `--cycles`, so a test that only passes on seed 4
+  is caught here rather than by someone else.
+- Building is done from the RAD Studio IDE. On a Community Edition licence there is no
+  command-line compile at all, so if you cannot build, ask - and never describe code as compiling
+  or tests as passing without a real build and a real run.
 
-```
-feature/2226-animals-can-block-units
-bugfix/300-barracks-recruits-list
-docs/ai-agent-rules
-```
+## 8. Review-loop control
 
-`docs/` covers documentation, the agent rules themselves, and build, CI and tooling
-configuration. It is the one prefix that does not need an issue, since there is often nothing to
-describe beyond the change itself - use `docs/<issue>-short-title` when an issue does exist. It is
-also the one prefix that is not split into a test pull request and a fix pull request, because
-there is no behaviour to reproduce.
+If anything in steps 4 to 7 came back short, go back to step 3 and run the pass again from the
+top. A fix applied without re-checking is how the second defect gets in.
 
-That exemption is exactly as narrow as it sounds: a change that touches `src/` is a feature or a
-bug fix, whatever else it also does. Infrastructure work on the engine - a new harness capability,
-something made testable - carries an issue and follows the rules for its kind. `docs/` is not a
-way around writing the test first.
+Only when a full pass comes back clean is the change ready to be shown to anyone.
 
-## Bugs: the test comes first, in its own pull request
+## After that
 
-A bug fix is two pull requests, in this order:
-
-1. **The reproduction.** A test that fails because of the bug. Nothing else - no fix, no cleanup.
-   This pull request is expected to be red on `master`: that is what proves the bug is real and
-   that the test actually catches it. A test that passes on `master` does not reproduce anything.
-2. **The fix**, branched off the first one, so that the same test turns green in it.
-
-The point of the order is that a test written after the fix only proves the fix does what its
-author remembers writing. Written first, it proves the bug existed.
-
-If the reproduction turns out to pass on `master`, that is a finding, not a formality to work
-around: the bug is somewhere else, or the understanding of it is wrong. Say so instead of
-adjusting the test until it goes red.
-
-## Features: tests and implementation in one pull request
-
-There is no bug to reproduce, so splitting them buys nothing. Keep the tests and the code they
-cover in the same pull request.
-
-## Before opening a pull request, check the work again
-
-Not a glance over the diff - a fresh pass with the issue open next to it:
-
-- Does the change do what the issue asked for? Not more, not less. Anything extra that crept in
-  either belongs in its own issue or comes out.
-- Does it follow the rules in `.ai/rules/`? The ones most often missed: naming and formatting
-  (`styleguide.md`), the determinism boundary (`project-rules.md`), serialization of new gameplay
-  fields (`project-rules.md`), new units registered in the `.dpr` (`coding-rules.md`), and
-  comments that say why rather than what (`comments.md`).
-- Was it built and were the tests run? Report what actually ran and what it said. Never describe
-  code as compiling or tests as passing without a real build and a real run - see the build note
-  in `project.md`.
-
-**If anything is off, fix it and run the pass again from the top.** The check is repeated until it
-comes back clean, not performed once and filed away.
-
-What the pull request body itself has to contain - and why `Related to` is the default rather than
-`Closes` - is in `pull-request.md`. The outcome of this check is part of it: the scope bullets and
-the verification section are where it gets written down.
-
-## Review
-
-Answer review comments where they were made, and say what changed rather than only that you
-agree. When a comment leads to a different change than the one suggested, or when something else
-gets changed along the way, say that in the pull request too - a reviewer should never have to
-discover an unexplained rename in a force-push. See `pull-request.md`.
+Opening the pull request is not the end, and neither is merging it. Review comments are part of
+the work: answer them, apply what is right, and say plainly when you disagree and why. What the
+description has to contain is in `pull-request.md`.

--- a/.ai/rules/workflow.md
+++ b/.ai/rules/workflow.md
@@ -1,0 +1,70 @@
+# Workflow
+
+How a change gets from an idea to a merged pull request. This is about process; what the code
+itself has to look like is in the other rule files.
+
+## Every change starts from a GitHub issue
+
+The issue is what the branch is named after and what the pull request closes, and it is where the
+problem is described so that the pull request can stay about the solution. If there is no issue
+for the task yet, open one before starting.
+
+## Branch naming
+
+```
+feature/<issue>-short-title
+bugfix/<issue>-short-title
+```
+
+The issue number comes first, then a short lowercase kebab-case title - enough to recognise the
+branch in a list, not a summary of the change. As used in the repository:
+
+```
+feature/2226-animals-can-block-units
+bugfix/300-barracks-recruits-list
+```
+
+## Bugs: the test comes first, in its own pull request
+
+A bug fix is two pull requests, in this order:
+
+1. **The reproduction.** A test that fails because of the bug. Nothing else - no fix, no cleanup.
+   This pull request is expected to be red on `master`: that is what proves the bug is real and
+   that the test actually catches it. A test that passes on `master` does not reproduce anything.
+2. **The fix**, branched off the first one, so that the same test turns green in it.
+
+The point of the order is that a test written after the fix only proves the fix does what its
+author remembers writing. Written first, it proves the bug existed.
+
+If the reproduction turns out to pass on `master`, that is a finding, not a formality to work
+around: the bug is somewhere else, or the understanding of it is wrong. Say so instead of
+adjusting the test until it goes red.
+
+## Features: tests and implementation in one pull request
+
+There is no bug to reproduce, so splitting them buys nothing. Keep the tests and the code they
+cover in the same pull request.
+
+## Before opening a pull request, check the work again
+
+Not a glance over the diff - a fresh pass with the issue open next to it:
+
+- Does the change do what the issue asked for? Not more, not less. Anything extra that crept in
+  either belongs in its own issue or comes out.
+- Does it follow the rules in `.ai/rules/`? The ones most often missed: naming and formatting
+  (`styleguide.md`), the determinism boundary (`project-rules.md`), serialization of new gameplay
+  fields (`project-rules.md`), new units registered in both the `.dpr` and the `.dproj`
+  (`project-layout.md`), and comments that say why rather than what (`comments.md`).
+- Was it built and were the tests run? Report what actually ran and what it said. Never describe
+  code as compiling or tests as passing without a real build and a real run - see the build note
+  in `project.md`.
+
+**If anything is off, fix it and run the pass again from the top.** The check is repeated until it
+comes back clean, not performed once and filed away.
+
+## Review
+
+Answer review comments where they were made, and say what changed rather than only that you
+agree. When a comment leads to a different change than the one suggested, or when something else
+gets changed along the way, say that in the pull request too - a reviewer should never have to
+discover an unexplained rename in a force-push.

--- a/.ai/rules/workflow.md
+++ b/.ai/rules/workflow.md
@@ -66,8 +66,8 @@ Not a glance over the diff - a fresh pass with the issue open next to it:
   either belongs in its own issue or comes out.
 - Does it follow the rules in `.ai/rules/`? The ones most often missed: naming and formatting
   (`styleguide.md`), the determinism boundary (`project-rules.md`), serialization of new gameplay
-  fields (`project-rules.md`), new units registered in both the `.dpr` and the `.dproj`
-  (`project-layout.md`), and comments that say why rather than what (`comments.md`).
+  fields (`project-rules.md`), new units registered in the `.dpr` (`coding-rules.md`), and
+  comments that say why rather than what (`comments.md`).
 - Was it built and were the tests run? Report what actually ran and what it said. Never describe
   code as compiling or tests as passing without a real build and a real run - see the build note
   in `project.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ carrying business logic. Treat advice aimed at enterprise Delphi projects with s
 
 ## The rules live in `.ai/rules/`
 
-That directory is the source of truth. This file is the entry point and a summary of the things
-that are easiest to get wrong; it deliberately does not repeat the rules.
+That directory is the source of truth, and this file does not restate it. What follows is an
+index of the rule files, plus a few points that carry more weight than the rest - not a shorter
+version of the rules, and not the subset that matters. Read the rule files themselves.
 
 Read `.ai/rules/agent-rules.md` first, then whichever of the others the task touches:
 
@@ -18,10 +19,10 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 | [.ai/rules/agent-rules.md](.ai/rules/agent-rules.md) | How to behave: understand before acting, workflow, adding features, refactoring, communication |
 | [.ai/rules/workflow.md](.ai/rules/workflow.md) | Getting a change merged: issues, branch naming, tests-before-fix for bugs, the pre-PR re-check |
 | [.ai/rules/pull-request.md](.ai/rules/pull-request.md) | Writing the pull request body: linking the issue, review intent, what was verified and what was not |
-| [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology, build system |
-| [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, project registration, global instances |
-| [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers, headless mode |
-| [.ai/rules/coding-rules.md](.ai/rules/coding-rules.md) | Writing code: general rules, Delphi language rules, compiler directives, error handling, uses clause ordering |
+| [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology |
+| [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, global instances |
+| [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers |
+| [.ai/rules/coding-rules.md](.ai/rules/coding-rules.md) | Writing code: general rules, Delphi language features, registering a new unit, error handling, uses clause ordering |
 | [.ai/rules/styleguide.md](.ai/rules/styleguide.md) | Naming and formatting: prefixes, casing, layout, no magic numbers |
 | [.ai/rules/comments.md](.ai/rules/comments.md) | Writing comments: philosophy, tone, what to comment, structural rules |
 | [.ai/rules/testing.md](.ai/rules/testing.md) | Tests: the two test projects, how to write and run each of them |
@@ -29,10 +30,8 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 
 ## Work is tracked on GitHub
 
-Every change to the game starts from an issue and branches as `feature/<issue>-short-title` or
-`bugfix/<issue>-short-title`, and for a bug the reproducing test lands in its own pull request
-before the fix. Documentation, rules and tooling go on a `docs/` branch and need neither. Before opening any pull request, check the work against the issue and the rules
-again, and keep checking until the pass comes back clean. See `.ai/rules/workflow.md`.
+Branch naming, when a bug's test comes before its fix, and the check to run before opening a
+pull request are all in `.ai/rules/workflow.md`. Read it before starting, not before pushing.
 
 ## When invoked
 
@@ -56,12 +55,6 @@ the simulation side. The short version:
 - Do not let gameplay logic depend on memory addresses, pointer values, or allocation order.
 - Do not rely on iteration order of unordered containers (`TDictionary`); use `TList<>` or another ordered structure when sequence matters.
 - Any new gameplay field must be considered for savegame serialization at the moment it is added.
-
-## A new unit is not part of the project until it is registered
-
-Adding a unit to some other unit's `uses` clause is **not** enough - it must appear in the
-project file, or the IDE and the build will not see it. Every project here has both a `.dpr` and
-a `.dproj`, and both need the entry. See `.ai/rules/project-layout.md`.
 
 ## The build may not be available to you
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 | [.ai/rules/workflow.md](.ai/rules/workflow.md) | Getting a change merged: issues, branch naming, tests-before-fix for bugs, the pre-PR re-check |
 | [.ai/rules/pull-request.md](.ai/rules/pull-request.md) | Writing the pull request body: linking the issue, review intent, what was verified and what was not |
 | [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology, build system |
-| [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, project registration, global singletons |
+| [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, project registration, global instances |
 | [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers, headless mode |
 | [.ai/rules/coding-rules.md](.ai/rules/coding-rules.md) | Writing code: general rules, Delphi language rules, compiler directives, error handling, uses clause ordering |
 | [.ai/rules/styleguide.md](.ai/rules/styleguide.md) | Naming and formatting: prefixes, casing, layout, no magic numbers |
@@ -44,16 +44,17 @@ again, and keep checking until the pass comes back clean. See `.ai/rules/workflo
 
 ## Determinism comes first
 
-The gameplay simulation must produce identical results on every machine, because Multiplayer,
-Replays and Savegames all depend on it. This is the one thing that is easy to break by accident
-and expensive to debug afterwards, so it outranks readability, performance and convenience.
+The gameplay simulation must produce identical results on every machine, because Multiplayer and
+Replays both depend on it. This is the one thing that is easy to break by accident and expensive
+to debug afterwards, so it outranks readability, performance and convenience.
 
 `.ai/rules/project-rules.md` defines exactly where the boundary runs and what is forbidden on
 the simulation side. The short version:
 
 - Use the project RNG (`KaMRandom` and friends), never `Random`, and keep the call order stable.
-- Do not read real time, frame time, render state, UI state, camera position or pointer values.
-- Do not rely on container iteration order.
+- Do not read real time, frame time, render state, UI state, or camera position from simulation code.
+- Do not let gameplay logic depend on memory addresses, pointer values, or allocation order.
+- Do not rely on iteration order of unordered containers (`TDictionary`); use `TList<>` or another ordered structure when sequence matters.
 - Any new gameplay field must be considered for savegame serialization at the moment it is added.
 
 ## A new unit is not part of the project until it is registered

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 | File | Read it when you need |
 |---|---|
 | [.ai/rules/agent-rules.md](.ai/rules/agent-rules.md) | How to behave: understand before acting, workflow, adding features, refactoring, communication |
-| [.ai/rules/workflow.md](.ai/rules/workflow.md) | Getting a change merged: issues, branch naming, tests-before-fix for bugs, the pre-PR re-check |
-| [.ai/rules/pull-request.md](.ai/rules/pull-request.md) | Writing the pull request body: linking the issue, review intent, what was verified and what was not |
+| [.ai/rules/workflow.md](.ai/rules/workflow.md) | Working a change through: investigate, implement, review your own result, verify, repeat until clean |
+| [.ai/rules/pull-request.md](.ai/rules/pull-request.md) | Writing the pull request body: the template, and what belongs there that the diff does not say |
 | [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology |
 | [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, global instances |
 | [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers |
@@ -28,10 +28,12 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 | [.ai/rules/testing.md](.ai/rules/testing.md) | Tests: the two test projects, how to write and run each of them |
 | [.ai/rules/tools-and-utils.md](.ai/rules/tools-and-utils.md) | Anything under `Utils/`: what each tool is for, status matrix, maintenance |
 
-## Work is tracked on GitHub
+## How a change gets worked
 
-Branch naming, when a bug's test comes before its fix, and the check to run before opening a
-pull request are all in `.ai/rules/workflow.md`. Read it before starting, not before pushing.
+A task arrives from an issue or from the chat, gets investigated before it gets written, and then
+gets reviewed by you - against the task, its scope, the rules, and a real build and run - until a
+full pass comes back clean. That loop is `.ai/rules/workflow.md`. Read it before starting, not
+before pushing.
 
 ## When invoked
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 | File | Read it when you need |
 |---|---|
 | [.ai/rules/agent-rules.md](.ai/rules/agent-rules.md) | How to behave: understand before acting, workflow, adding features, refactoring, communication |
+| [.ai/rules/workflow.md](.ai/rules/workflow.md) | Getting a change merged: issues, branch naming, tests-before-fix for bugs, the pre-PR re-check |
 | [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology, build system |
 | [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, project registration, global singletons |
 | [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers, headless mode |
@@ -24,6 +25,13 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 | [.ai/rules/comments.md](.ai/rules/comments.md) | Writing comments: philosophy, tone, what to comment, structural rules |
 | [.ai/rules/testing.md](.ai/rules/testing.md) | Tests: the two test projects, how to write and run each of them |
 | [.ai/rules/tools-and-utils.md](.ai/rules/tools-and-utils.md) | Anything under `Utils/`: what each tool is for, status matrix, maintenance |
+
+## Work is tracked on GitHub
+
+Every change starts from an issue, branches as `feature/<issue>-short-title` or
+`bugfix/<issue>-short-title`, and for a bug the reproducing test lands in its own pull request
+before the fix. Before opening any pull request, check the work against the issue and the rules
+again, and keep checking until the pass comes back clean. See `.ai/rules/workflow.md`.
 
 ## When invoked
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md
+
+You are an expert Delphi / Object Pascal developer working on **KaM Remake** - an open-source
+remake of "Knights and Merchants: The Shattered Kingdom". It is a mature game engine written
+from scratch, with its own UI controls, its own renderer and its own deterministic simulation.
+It is not a business application: there is no database, no ORM, no REST layer and no VCL forms
+carrying business logic. Treat advice aimed at enterprise Delphi projects with suspicion here.
+
+## The rules live in `.ai/rules/`
+
+That directory is the source of truth. This file is the entry point and a summary of the things
+that are easiest to get wrong; it deliberately does not repeat the rules.
+
+Read `.ai/rules/agent-rules.md` first, then whichever of the others the task touches:
+
+| File | Read it when you need |
+|---|---|
+| [.ai/rules/agent-rules.md](.ai/rules/agent-rules.md) | How to behave: understand before acting, workflow, adding features, refactoring, communication |
+| [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology, build system |
+| [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, project registration, global singletons |
+| [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers, headless mode |
+| [.ai/rules/coding-rules.md](.ai/rules/coding-rules.md) | Writing code: general rules, Delphi language rules, compiler directives, error handling, uses clause ordering |
+| [.ai/rules/styleguide.md](.ai/rules/styleguide.md) | Naming and formatting: prefixes, casing, layout, no magic numbers |
+| [.ai/rules/comments.md](.ai/rules/comments.md) | Writing comments: philosophy, tone, what to comment, structural rules |
+| [.ai/rules/testing.md](.ai/rules/testing.md) | Tests: the two test projects, how to write and run each of them |
+| [.ai/rules/tools-and-utils.md](.ai/rules/tools-and-utils.md) | Anything under `Utils/`: what each tool is for, status matrix, maintenance |
+
+## When invoked
+
+- Read the relevant sources before changing them. Do not assume an API exists - this codebase
+  renames things often, and a plausible-looking identifier is frequently the old one.
+- Work out which side of the determinism boundary the code is on before touching it.
+- Keep the change small and in the style of the code around it.
+- Say what you verified and what you only assumed.
+
+## Determinism comes first
+
+The gameplay simulation must produce identical results on every machine, because Multiplayer,
+Replays and Savegames all depend on it. This is the one thing that is easy to break by accident
+and expensive to debug afterwards, so it outranks readability, performance and convenience.
+
+`.ai/rules/project-rules.md` defines exactly where the boundary runs and what is forbidden on
+the simulation side. The short version:
+
+- Use the project RNG (`KaMRandom` and friends), never `Random`, and keep the call order stable.
+- Do not read real time, frame time, render state, UI state, camera position or pointer values.
+- Do not rely on container iteration order.
+- Any new gameplay field must be considered for savegame serialization at the moment it is added.
+
+## A new unit is not part of the project until it is registered
+
+Adding a unit to some other unit's `uses` clause is **not** enough - it must appear in the
+project file, or the IDE and the build will not see it. Every project here has both a `.dpr` and
+a `.dproj`, and both need the entry. See `.ai/rules/project-layout.md`.
+
+## The build may not be available to you
+
+Building is done from the RAD Studio IDE, and on a Community Edition licence that is the only
+option - CE refuses command-line compilation through both `dcc32` and `msbuild`. Never report
+that something compiles or that tests pass unless a build and a run actually happened; ask for
+the build instead.
+
+The game tests are then run from the command line:
+
+```
+Utils\Testing_GameTests\Testing_GameTests.exe --run-all
+```
+
+## Tests
+
+Two separate projects, with different purposes and different frameworks - use the one that fits
+and follow the conventions already in it. Details in `.ai/rules/testing.md`.
+
+- `Utils/UnitTests` - DUnit (`TTestCase`, `published` methods) for pure logic: utilities, points,
+  streams, containers.
+- `Utils/Testing_GameTests` - the project's own harness (`TKMTest`, `SetUp` / `DoTick` /
+  `CheckResult`) that runs a real headless game. For gameplay behaviour.
+
+## Output style
+
+- Be direct and technical. Give a recommendation rather than a survey of options.
+- State assumptions and the limits of what you checked.
+- Prefer complete, compilable code over sketches.
+- When you create units, say exactly where they must be registered.
+- Use American English for identifiers and comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 |---|---|
 | [.ai/rules/agent-rules.md](.ai/rules/agent-rules.md) | How to behave: understand before acting, workflow, adding features, refactoring, communication |
 | [.ai/rules/workflow.md](.ai/rules/workflow.md) | Getting a change merged: issues, branch naming, tests-before-fix for bugs, the pre-PR re-check |
+| [.ai/rules/pull-request.md](.ai/rules/pull-request.md) | Writing the pull request body: linking the issue, review intent, what was verified and what was not |
 | [.ai/rules/project.md](.ai/rules/project.md) | What KaM Remake is: concept, features, technology, architecture, terminology, build system |
 | [.ai/rules/project-layout.md](.ai/rules/project-layout.md) | Where code lives: repository layout, file and unit organization, project registration, global singletons |
 | [.ai/rules/project-rules.md](.ai/rules/project-rules.md) | Engine rules: world representation, the determinism boundary, savegame serialization, entity pointers, headless mode |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,9 @@ Read `.ai/rules/agent-rules.md` first, then whichever of the others the task tou
 
 ## Work is tracked on GitHub
 
-Every change starts from an issue, branches as `feature/<issue>-short-title` or
+Every change to the game starts from an issue and branches as `feature/<issue>-short-title` or
 `bugfix/<issue>-short-title`, and for a bug the reproducing test lands in its own pull request
-before the fix. Before opening any pull request, check the work against the issue and the rules
+before the fix. Documentation, rules and tooling go on a `docs/` branch and need neither. Before opening any pull request, check the work against the issue and the rules
 again, and keep checking until the pass comes back clean. See `.ai/rules/workflow.md`.
 
 ## When invoked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+See **[AGENTS.md](AGENTS.md)** - it is the entry point for all AI assistants working on this
+project, and it indexes the rules in `.ai/rules/`.
+
+Nothing is duplicated here on purpose: two copies of the same rules drift apart.


### PR DESCRIPTION
## Title

Add AGENTS.md and rules for how an AI agent should work in this repository

## Description

`.ai/rules/` is only read by whoever knows to look there. This adds `AGENTS.md`, the file AI tools
look for by default, as an index into those rules; corrects the statements in them that did not
match the code; and adds three files covering the parts an agent gets wrong here - the workflow,
the pull request body, and writing tests.

### Critical information that is not in the code

Most of this has already been through your review twice, and the current state is what came back
from it. What each round changed:

**Round 1 - the rules that were simply wrong.** The RNG entry said `gRandom`, which does not
exist; it is the `KaMRandom` family in `KM_CommonUtils`, seeded by `SetKaMSeed`, with the RNG spy
label on every call site. `project.md` claimed the Delphi range twice, differently. Corrected.

**Round 2 - your notes on #320.** You took several of these into master yourself, so the branch no
longer touches `coding-rules.md` or `project-layout.md` at all - the `with` rule, the nil-guard
getters, unit registration and the globals table are all there in your wording now. Also dropped:
the `Compiler & Build System` section you had removed twice, the `headless mode` section (it said
`gRender` is nil in a test run, which #319 later proved false - the render is blind, not nil), the
issue precondition, the branch naming scheme, and the `docs/` prefix I invented. `testing.md` was
rewritten from the suite as it stands rather than from what I assumed it did.

**`workflow.md` is now the review loop**, not paperwork: get the task from an issue *or the chat*,
investigate before writing, then four passes over your own result - does it answer the task, has
the scope crept, does it follow the stack and style, does it build and run - and back to
implementation until a pass comes back clean.

**`pull-request.md` is a template**, roughly this one: a title, a paragraph, and a section for
what the diff cannot say. `Related to` by default; `Closes` only when the issue is really
finished.

**The two "what review keeps sending back" sections** are collected from your actual notes on
#319, #322 and this PR, plus what you changed when merging #322 - inlining `KILL_TICK`, dropping
the `utRecruit` filter as unfalsifiable, collapsing `Format` onto one line. They are written as
observations that cost a review round, not as preferences, so they keep working for the next agent
without needing you in the loop.

The one place I did not follow a note literally is called out in the file: "simplify to aTicks"
cannot apply to a test whose timing the game chooses rather than the test, because that only holds
on one seed and the suite runs `--cycles`.
