### PR TITLE
Take a recruit off the barracks list when he dies

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -32,6 +32,7 @@ KaM Remake Beta r_____ []
 + Fixed file access error on startup when game tried to write to log
 + Fixed occasional an error caused by clicking a message in the message log after changing active hand
 + Fixed archers taking long detours in front of their group
++ Fixed crash on equipping a warrior after a recruit died inside the Barracks (#300)
 
 Campaigns:
 + Added French translations for 8 campaigns (and other minor corrections)

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -294,6 +294,8 @@ type
   TKMUnitRecruit = class(TKMSettledUnit)
   protected
     procedure TaskGetWork; override;
+  public
+    procedure Kill(aFrom: TKMHandID; aShowAnimation, aForceDelay: Boolean); override;
   end;
 
   //Serf - transports all wares between houses
@@ -772,6 +774,20 @@ begin
 
   if enemy <> nil then
     fTask := TKMTaskThrowRock.Create(Self, enemy);
+end;
+
+
+procedure TKMUnitRecruit.Kill(aFrom: TKMHandID; aShowAnimation, aForceDelay: Boolean);
+var
+  alreadyDeadOrDying: Boolean;
+begin
+  alreadyDeadOrDying := IsDeadOrDying; //Inherited will kill the unit
+  inherited;
+
+  //Report to the Barracks that we have died. It only takes a recruit off its list when he walks
+  //out of the door, so one who dies inside would stay on it and get equipped as a warrior later
+  if not alreadyDeadOrDying and (fInHouse is TKMHouseBarracks) then
+    TKMHouseBarracks(fInHouse).RecruitsRemove(Self);
 end;
 
 


### PR DESCRIPTION
Closes #300.

The fix for the crash the tests in #322 reproduce. Those tests are on master now, so this branch
is one commit, one file, sixteen lines.

## Summary

* **What the issue reports:** `Unit could be silently killed only inside some House`, asserted by
  `KillInHouse` when `TKMHouseBarracks.EquipWarrior` calls it.
* **What this delivers:** a recruit takes himself off the barracks list when he dies, so
  `EquipWarrior` never reaches a dead one.
* **Deliberately left out:** `EquipWarrior` itself, and the raw pointers in `fRecruitsList`. See
  *Risks and open questions*.

## The cause

`fRecruitsList` only ever loses an entry in one place - `TKMUnitActionGoInOut.WalkOut`, when a
recruit walks out of the door. A recruit who dies without walking out is never taken off it.
`RecruitsAdd` also stores a plain pointer and takes no counted reference, so nothing keeps him
alive on the list's behalf.

`RecruitsCount` then counts a recruit who is not there, `CanEquip` says yes, and `EquipWarrior`
kills him with `KillInHouse`, which opens with `Assert(fInHouse <> nil)`.

`TKMTaskDie` does start a walk out for a unit who is inside, so the entry is not stranded forever
- but the walk takes several ticks, and the recruit is on the list for all of them. That window is
what `TKMTest_RecruitKilledInside` catches one tick after the kill, and what
`TKMTest_RecruitStarvedInside` catches on every seed from 4 to 9.

## The fix

```pascal
procedure TKMUnitRecruit.Kill(aFrom: TKMHandID; aShowAnimation, aForceDelay: Boolean);
var
  alreadyDeadOrDying: Boolean;
begin
  alreadyDeadOrDying := IsDeadOrDying; //Inherited will kill the unit
  inherited;

  //Report to the Barracks that we have died. It only takes a recruit off its list when he walks
  //out of the door, so one who dies inside would stay on it and get equipped as a warrior later
  if not alreadyDeadOrDying and (fInHouse is TKMHouseBarracks) then
    TKMHouseBarracks(fInHouse).RecruitsRemove(Self);
end;
```

This mirrors `TKMUnitWarrior.Kill`, which reports a death to the warrior's group the same way,
down to the `alreadyDeadOrDying` guard. `KM_Units` already uses `KM_HouseBarracks`.

It covers dying of hunger and `Actions.UnitKill`. The third way for a listed recruit to die, the
barracks being demolished, was already handled by `Demolish` clearing the whole list - and its
comment describes this very failure: "it can cause crashes while saving under the right conditions
when a recruit is then killed".

## Review intent

* **Where this went before, and why it moved.** It was in `TKMHand.UnitDied` first. That worked,
  but it had the unit report its death to the hand and then the hand reach back into the unit to
  find the house and update it. The recruit telling his own barracks is the same shape the engine
  already uses for warriors and groups.
* **Not `CloseUnit`,** which looks like the natural home next to `fHome.SetWorker(nil)`. It runs
  from `TKMTaskDie` several ticks later, so it does not close the window; and `KillInHouse` calls
  it while `EquipWarrior` is midway through removing the entry itself, which would make
  `EquipWarrior` delete the wrong one. The comment in `TKMTaskDie` warns about that sharing
  already.
* **`EquipWarrior` is untouched, on purpose.** With the list no longer holding recruits who are
  elsewhere, taking the first one is correct again, and a second layer would hide the next leak
  rather than fail on it.

## Determinism and savegames

* **Savegame format:** unchanged. No field added, nothing serialized differently.
* **Determinism:** a recruit is removed from a list he should not have been on. Order of the
  remaining entries is untouched, no RNG is consumed, and the removal happens at a fixed point in
  `Kill`, which is already part of the simulation on every client.
* **Multiplayer:** the broken state was reachable identically on every client, so it did not
  desync - it crashed everyone who equipped from that barracks.

## Verification

Built from the IDE and run, with the tests as they are on master:

| | result |
|---|---|
| `--run-all` | **22/22** |
| `--run=Recruit --cycles=8` | **32/32**, seeds 4 to 11 |

Before the fix, `TKMTest_RecruitStarvedInside` failed on every seed from 4 to 9 and
`TKMTest_RecruitKilledInside` failed one tick after the kill.

**Not run:** a multiplayer game. The determinism reasoning above is from reading the code.

## Risks and open questions

* `fRecruitsList` still holds plain pointers with no counted reference. Nothing known leaves a
  dead recruit on it now, but the list would still dangle if some future path removed a unit
  without going through `Kill`. #317 tried that ownership rework and is closed as the wrong shape
  for this bug; it deserves its own issue.
* `TKMHouseBarracks.SyncLoad` leaves `nil` in the list when a UID does not resolve, rather than
  dropping the entry. Same category.
* `CreateRecruitInside` still says "When walking out Home is used to remove recruit from barracks",
  while the removal has been keyed on `InHouse` for some time. Stale comment, not touched here.
