### PR TITLE
Add a game test for archers sent across the formation in a firefight

### DIFF
--- a/Utils/Testing_GameTests/KM_Test_Archers_GoFar.pas
+++ b/Utils/Testing_GameTests/KM_Test_Archers_GoFar.pas
@@ -1,0 +1,189 @@
+unit KM_Test_Archers_GoFar;
+{$I KaM_Remake.inc}
+interface
+uses
+  KM_Test;
+
+
+type
+  // Two archer squads shoot it out 6 tiles apart, 21 per rank, 6 ranks deep.
+  // A member's index in fMembers is his formation slot, and deaths shift those indexes.
+  // Fails when an archer walks 10+ tiles to a spot a comrade stands twice nearer.
+  TKMTest_ArchersGoFar = class(TKMTest)
+  private
+    procedure CheckWalkOrders(aTick: Cardinal);
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
+    function DoTick(aTick: Cardinal): Boolean; override;
+    procedure CheckResult; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+
+implementation
+uses
+  Math, SysUtils, TypInfo,
+  KM_Defaults, KM_Points,
+  KM_GameApp, KM_HandsCollection, KM_HandTypes, KM_Viewport,
+  KM_Units, KM_UnitWarrior, KM_UnitGroup, KM_UnitGroupTypes, KM_UnitActionWalkTo;
+
+
+const
+  // Gap between the front ranks. Bowman range is 4..10.99, so both can shoot
+  ARMIES_GAP = 6;
+
+  // The longest walk an archer can legitimately be ordered to make in this setup
+  MAX_WALK_DIST = 10;
+
+
+// Distance from aLoc to the nearest other member of aUnit's group, MaxSingle if none
+function NearestComrade(aHand: Integer; aUnit: TKMUnit; const aLoc: TKMPoint; out aUID: Integer): Single;
+begin
+  Result := MaxSingle;
+  aUID := 0;
+
+  var group := gHands[aHand].UnitGroups.GetGroupByMember(TKMUnitWarrior(aUnit));
+  if group = nil then Exit;
+
+  for var I := 0 to group.Count - 1 do
+  if group.Members[I] <> aUnit then
+  begin
+    var d := KMLengthDiag(group.Members[I].Position, aLoc);
+    if d < Result then
+    begin
+      Result := d;
+      aUID := group.Members[I].UID;
+    end;
+  end;
+end;
+
+
+// Group state behind a far walk order, so a red run reads without a debugger
+function DescribeFarWalk(aTick: Cardinal; aHand: Integer; aUnit: TKMUnit; const aWalkTo: TKMPoint;
+                         aDist, aNearest: Single; aNearestUID: Integer): string;
+begin
+  Result := Format('Tick %d: archer %d of hand %d standing at %s was ordered to walk to %s, %.1f tiles away',
+                   [aTick, aUnit.UID, aHand, TypeToString(aUnit.Position), TypeToString(aWalkTo), aDist]);
+
+  var group := gHands[aHand].UnitGroups.GetGroupByMember(TKMUnitWarrior(aUnit));
+  if group = nil then Exit;
+
+  var idx := -1;
+  for var I := 0 to group.Count - 1 do
+    if group.Members[I] = aUnit then
+      idx := I;
+
+  Result := Result + Format('. Group %d: he is member %d of %d, %d per row, order %s at %s.'
+                          + ' Comrade %d stands only %.1f tiles from that spot',
+                            [group.UID, idx, group.Count, group.UnitsPerRow,
+                             GetEnumName(TypeInfo(TKMGroupOrder), Integer(group.Order)),
+                             TypeToString(group.OrderLoc), aNearestUID, aNearest]);
+end;
+
+
+{ TKMTest_ArchersGoFar }
+procedure TKMTest_ArchersGoFar.SetUp;
+begin
+  inherited;
+
+  DYNAMIC_TERRAIN := False;
+
+  // Draw walk routes, so far walks can be seen in the test runner
+  SHOW_UNIT_ROUTES := True;
+
+  // 3 minutes of game time, arrows start flying within the first few ticks
+  fDuration := 3 * 600;
+
+  gGameApp.NewGameEmptyMap(64, 64);
+
+  // Pull the camera out to fit both squads and their routes into view
+  if (gGameApp.Game <> nil) and (gGameApp.Game.ActiveInterface <> nil) then
+  begin
+    var viewport := gGameApp.Game.ActiveInterface.Viewport;
+    viewport.Zoom := viewport.Zoom / 2;
+  end;
+
+  // Player controlled, so that no AI general orders the squads about
+  gHands[0].HandType := hndHuman;
+  gHands[1].HandType := hndHuman;
+
+  // An odd rank centres the leader, so both formations line up exactly
+  var leader0 := KMPoint(29, 32);
+  var leader1 := KMPoint(leader0.X + ARMIES_GAP, leader0.Y);
+
+  var group0 := gHands[0].AddUnitGroup(utBowman, leader0, dirE, 21, 21 * 6);
+  var group1 := gHands[1].AddUnitGroup(utBowman, leader1, dirW, 21, 21 * 6);
+
+  group0.OrderAttackUnit(group1.Members[0], True);
+  group1.OrderAttackUnit(group0.Members[0], True);
+end;
+
+
+procedure TKMTest_ArchersGoFar.TearDown;
+begin
+  inherited;
+  DYNAMIC_TERRAIN := True;
+  SHOW_UNIT_ROUTES := False;
+end;
+
+
+// Nobody should cross the battlefield while the two squads shoot at each other
+procedure TKMTest_ArchersGoFar.CheckWalkOrders(aTick: Cardinal);
+begin
+  for var H := 0 to gHands.Count - 1 do
+    for var I := 0 to gHands[H].Units.Count - 1 do
+    begin
+      var U := gHands[H].Units[I];
+
+      if (U = nil) or U.IsDeadOrDying then Continue;
+      if not (U.Action is TKMUnitActionWalkTo) then Continue;
+
+      var walkTo := TKMUnitActionWalkTo(U.Action).WalkTo;
+      var dist := KMLengthDiag(U.Position, walkTo);
+
+      if dist <= MAX_WALK_DIST then Continue;
+
+      //Only a mistake when a comrade stands at least twice as close to that spot
+      var comradeUID: Integer;
+      var nearest := NearestComrade(H, U, walkTo, comradeUID);
+      if nearest * 2 > dist then Continue;
+
+      var s := DescribeFarWalk(aTick, H, U, walkTo, dist, nearest, comradeUID);
+      AssertTrue(False, s);
+    end;
+end;
+
+
+function TKMTest_ArchersGoFar.DoTick(aTick: Cardinal): Boolean;
+begin
+  CheckWalkOrders(aTick);
+
+  // Continue simulation (True) until one of the squads is wiped out
+  Result := (gHands[0].Stats.GetUnitQty(utAny) > 0) and (gHands[1].Stats.GetUnitQty(utAny) > 0);
+end;
+
+
+procedure TKMTest_ArchersGoFar.CheckResult;
+begin
+  // Nothing to check at the end, walk orders are checked as they are given
+end;
+
+
+class function TKMTest_ArchersGoFar.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBowman, tcCombat, tcPathfinding];
+end;
+
+
+class function TKMTest_ArchersGoFar.TestDescription: string;
+begin
+  Result := 'Archers in a firefight should not be ordered to walk across the whole battlefield.';
+end;
+
+
+initialization
+  RegisterTest(TKMTest_ArchersGoFar);
+end.

--- a/Utils/Testing_GameTests/Testing_GameTests.dpr
+++ b/Utils/Testing_GameTests/Testing_GameTests.dpr
@@ -18,6 +18,7 @@ uses
   Unit1 in 'Unit1.pas' {Form2},
 
   KM_Test in 'KM_Test.pas',
+  KM_Test_Archers_GoFar in 'KM_Test_Archers_GoFar.pas',
   KM_Test_Bakery in 'KM_Test_Bakery.pas',
   KM_Test_BuildingPlan in 'KM_Test_BuildingPlan.pas',
   KM_Test_FarmHarvest in 'KM_Test_FarmHarvest.pas',

--- a/Utils/Testing_GameTests/Testing_GameTests.dproj
+++ b/Utils/Testing_GameTests/Testing_GameTests.dproj
@@ -140,6 +140,7 @@
             <Form>Form2</Form>
         </DCCReference>
         <DCCReference Include="KM_Test.pas"/>
+        <DCCReference Include="KM_Test_Archers_GoFar.pas"/>
         <DCCReference Include="KM_Test_Bakery.pas"/>
         <DCCReference Include="KM_Test_BuildingPlan.pas"/>
         <DCCReference Include="KM_Test_FarmHarvest.pas"/>


### PR DESCRIPTION
The test half - the reproduction lands first, the fix follows in its own pull request.
**The test fails on master**, and that is intended.

## Summary

* **What goes wrong:** in a firefight an archer is ordered to walk right across his own formation -
  more than ten tiles - while a comrade of his stands a couple of tiles from the spot he is sent to.
* **What this delivers:** one game test that reaches that state through ordinary play, and a check
  that tells a misassigned slot apart from a walk the situation genuinely demands.
* **Deliberately left out:** the fix.

## The setup

Two bowman squads, 21 per rank and 6 ranks deep - 126 men each - six tiles apart and facing each
other on an empty 64x64 map. Bowman range is 4 to 10.99 tiles, so both front ranks can shoot from
the start, and both groups get an attack order the way a player would give one. Nothing pokes at
unit state afterwards - the firefight plays itself out and the test only watches.

An odd rank is what makes `GetPositionInGroup2` put the leader in the middle of it, so the two
formations span exactly the same rows, Y 22..42, opposite each other.

Hand 1 is switched to `hndHuman` so that no AI general orders the squads about behind the test's
back. `SHOW_UNIT_ROUTES` is on and the camera is pulled out, so that the run can be watched.

## The check

Every tick, for every archer whose action is `TKMUnitActionWalkTo`:

* the distance from where he stands to `WalkTo` must not exceed 10 tiles ...
* ... unless no comrade of his stands at least twice as close to that same spot.

The second half is what makes the test honest. When a squad has been shot down to its last man,
that man walking back to his order point ten tiles away is not a mistake - there is nobody closer
to send. The check let exactly that case through once the guard was added:

> Tick 956: archer 996494 of hand 1 standing at (36;41) was ordered to walk to (35;31), 10.4 tiles
> away. Group 12417309: he is member **0 of 1**, 1 per row, order goWalkTo at (35;31) Dir = dirW.

A failure message carries the group state - the member's index, the group size, units per row, the
group order and its location, and how close the nearest comrade to that spot was - so a red run can
be read without attaching a debugger.

## What it catches on master

An archer standing on one flank is handed a slot on the other and walks the whole width of the
line, while a comrade of his stands two or three tiles from that spot. A member's index in
`fMembers` is what maps him onto his slot, and every death shifts the indexes behind it.

Traced on an earlier 20 per rank version of this test: the same archer went from member 100 of 120
to member 91 once nine men ahead of him had died. Slot 100 is 24;22, slot 91 is 25;33, and those
are 11.4 tiles apart.

## Verification

Built from the IDE and run by hand. Red on master, green with the fix branch applied.

**Not run:** repeated seeds (`--cycles`), and `--run-all` alongside the other tests. The test costs
a few seconds of wall clock - 240 units, up to 1800 ticks, and it stops early once one squad is wiped
out.

## Risks and open questions

* The 10 tile threshold is a judgement call. The battlefield is 6 tiles of no man's land plus 6
  ranks on either side, so nothing in this setup should need more, but the number is not derived
  from anything in the game.
* Same for the "twice as close" factor in the comrade guard. It is there so that swapping two men
  who are both about equally far from the spot does not count as a finding, since such a swap saves
  nobody anything.

