### PR TITLE
Re-match group members to formation slots when one of them dies

### DIFF
--- a/src/units/KM_UnitGroup.pas
+++ b/src/units/KM_UnitGroup.pas
@@ -816,6 +816,13 @@ begin
 
   SetUnitsPerRow(fUnitsPerRow);
 
+  //A member's index in fMembers is what maps him onto his slot in the formation, and deleting one
+  //shifts everybody behind him - the man who was first in his rank inherits the last slot of the
+  //rank in front. Re-match the survivors to the slots now, while everyone is still standing where
+  //he was, so each of them takes the nearest spot instead of marching across the whole formation
+  if not IsDead then
+    HungarianReorderMembers;
+
   //If Group has died report to owner
   if IsDead and Assigned(OnGroupDied) then
     OnGroupDied(Self);
@@ -1370,6 +1377,7 @@ begin
     begin
       fOrderLoc.Loc := fMembers[0].Position; //Leader is already within range
       fOrderLoc.Dir := KMGetDirection(fMembers[0].Position, OrderTargetUnit.PositionNext);
+      HungarianReorderMembers; //We are about to send them to their slots around fOrderLoc
     end;
 
     //Next assign positions for each member (including leader)

--- a/src/utils/algorithms/KM_Hungarian.pas
+++ b/src/utils/algorithms/KM_Hungarian.pas
@@ -27,7 +27,7 @@ type
   TSimpleSolver = class(TAssignmentSolver)
   private
     TaskClaimedBy: array of Integer;
-    procedure DoSwaps;
+    function DoSwaps: Boolean;
   public
     procedure Solve; override; //Do calculation once Costs has been set up
   end;
@@ -67,6 +67,13 @@ type
 implementation
 const
   HUNGARIAN_MAX = 25; //Maximum number of agents hungarian can handle without causing performance issues
+  //How many times TSimpleSolver may swap tasks around. It would settle on its own in about a dozen
+  //passes, but the last of those buy nothing and the time adds up:
+  //Performance comparison for 120 unit group:
+  //DoSwaps x2 - 1.4ms
+  //DoSwaps x16 - 36ms
+  //DoSwaps x32 - 376ms
+  MAX_SWAP_PASSES = 6;
 
 
 { TSimpleSolver }
@@ -102,9 +109,14 @@ begin
     TaskClaimedBy[Solution[I]] := I; //Task is claimed, don't let another agent take it
   end;
 
-  //STEP 2: Swap tasks between agents when it's more efficient to do so
-  DoSwaps;
-  DoSwaps; //The more times we run it, the better the result. Twice gives good results without costing too much performance
+  //STEP 2: Swap tasks between agents while that keeps making the assignment better.
+  //STEP 1 hands out tasks in reverse order, so the agents it serves last (the first tasks) end up
+  //with whatever nobody else wanted. Two passes were not enough to undo that for large groups - in
+  //a 50 man formation it left a man walking across the whole line while his neighbour stood next
+  //to the free spot
+  for I := 0 to MAX_SWAP_PASSES - 1 do
+    if not DoSwaps then
+      Break;
 
   //Now see if we found a better solution than a basic 1 to 1 assignment between tasks and agents
   CostCurrent := 0;
@@ -123,9 +135,12 @@ end;
 
 
 //Swap tasks between agents when it is more efficient to do so
-procedure TSimpleSolver.DoSwaps;
+//Returns True if anything was swapped, so the caller can keep going until the assignment settles
+function TSimpleSolver.DoSwaps: Boolean;
 var I, J, TaskToSwap, Best, CostCurrent, CostSwap: Integer;
 begin
+  Result := False;
+
   for I := fHeight - 1 downto 0 do
   begin
     Best := MaxInt;
@@ -152,6 +167,7 @@ begin
       TaskClaimedBy[Solution[I]] := TaskClaimedBy[TaskToSwap]; //They now own our task
       Solution[I] := TaskToSwap; //We get their task
       TaskClaimedBy[TaskToSwap] := I; //We now own their task
+      Result := True;
     end;
   end;
 end;


### PR DESCRIPTION
The fix half. Branched off `master` on its own, so this is only the change itself - **the effect is
visible in the test from #324**, which is red on master and green with this branch applied.

## Summary

* **What goes wrong:** in a firefight an archer is ordered to walk right across his own formation -
  11 to 16 tiles on a 20 wide line - while a comrade of his stands two or three tiles from the spot
  he is sent to.
* **What this delivers:** the survivors are re-matched to their formation slots as soon as one of
  them dies, and the assignment solver used for large groups stops giving up halfway.
* **Deliberately left out:** the shape of the formation itself. A group keeps its full 20 tile
  width while it has 20 men, however few ranks are left, and this change does not touch that.

## The cause

A member's index in `TKMUnitGroup.fMembers` is what maps him onto his slot in the formation:

```pascal
function TKMUnitGroup.GetMemberLocExact(aIndex: Integer; out aExact: Boolean): TKMPoint;
begin
  Result := GetPositionInGroup2(fOrderLoc.Loc.X, fOrderLoc.Loc.Y,
                                fOrderLoc.Dir, aIndex, fUnitsPerRow, ...);
```

`Member_Died` drops the casualty out of that list with `fMembers.Delete(I)`, which shifts everybody
behind him by one. One step in index space is one step along a rank - until it crosses a rank
boundary, and then it is the whole width of the formation on the map.

With 20 per rank and the anchor at 29;32 facing east, slot 100 is 24;22 and slot 91 is 25;33. Those
are 11.4 tiles apart, and nine deaths ahead of a man turn the one into the other. That is what the
test caught first, on the archer standing at 24;22.

`HungarianReorderMembers` exists for exactly this - its own comment says it would rather have
"20 members take 1 step than 1 member take 10 steps" - but it was only reached from
`TKMUnitGroup.OrderWalk` and from the branch of `OrderAttackUnit` that relocates the whole group.
Neither of those runs when a man simply dies mid-firefight.

There is a second layer underneath. For more than 25 agents `HungarianMatchPoints` does not use the
Hungarian algorithm at all, it falls back to `TSimpleSolver`, whose greedy first step hands out
tasks in reverse order:

```pascal
for I := fHeight - 1 downto 0 do   //slots, last to first
  ...claim nearest unclaimed agent...
```

The slots served last are the low indexes - the front rank - and they get whatever nobody else
wanted. Two `DoSwaps` passes were meant to repair that, and for a 50 man group they do not: with the
reorder in place but the solver untouched, a man was still sent 12.8 tiles to a front rank slot
while a comrade stood 3.0 tiles from it.

## The fix

**`Member_Died`**, right after `SetUnitsPerRow` so the new rank width is already accounted for:

```pascal
if not IsDead then
  HungarianReorderMembers;
```

**`OrderAttackUnit`**, the branch where the leader is already within range. Its sibling branch, the
one that walks the group closer, has always reordered before handing out slots; this one sets a new
`fOrderLoc` and did not:

```pascal
fOrderLoc.Loc := fMembers[0].Position; //Leader is already within range
fOrderLoc.Dir := KMGetDirection(fMembers[0].Position, OrderTargetUnit.PositionNext);
HungarianReorderMembers; //We are about to send them to their slots around fOrderLoc
```

**`TSimpleSolver`** now keeps swapping while that improves the assignment, instead of stopping after
two passes. `DoSwaps` reports whether it changed anything; every swap strictly lowers the total
cost, so the loop converges on its own and the pass cap is only a backstop:

```pascal
Passes := 0;
repeat
  Swapped := DoSwaps;
  Inc(Passes);
until not Swapped or (Passes >= MAX_SWAP_PASSES);
```

In an offline model of this battle it settles in 3 to 6 passes on average for a 120 man group, and
the worst assigned walk drops from 17-19 tiles to 7-10.

## Determinism and savegames

* **Savegame format:** unchanged. No field added, nothing serialized differently. `fMembers` is
  still written as a list of UIDs - the order within that list changes, but the format does not.
* **Determinism:** neither `HungarianReorderMembers` nor the solver consumes RNG, and the reorder
  happens at a fixed point in `Member_Died`, which is part of the simulation on every client. Two
  clients that saw the same death produce the same member order.
* **Replays** recorded before this change will not match, the same as for any change to unit
  behaviour.

## Verification

Built from the IDE and run by hand: the test from #324 goes from red to green.

**Not run:** repeated seeds (`--cycles`), `--run-all`, and a multiplayer session. The determinism
argument above is from reading the code, not from a session with two clients.

## Risks and open questions

* **The solver change is global.** `TSimpleSolver` serves every group of more than 25 that is given
  a walk order, not just archers under fire. It only ever lowers the total cost, so formations
  should come out tidier, but it now costs 3 to 6 swap passes instead of 2.
* **Pairwise swapping settles in a local optimum.** In an offline model where nobody moves between
  deaths a couple of assignments still came out just over 10 tiles. If that turns out to matter in
  play, the next step is raising `HUNGARIAN_MAX` so that medium sized groups get the exact algorithm
  rather than making the swap loop work harder.
* **The reorder now runs once per death.** For a 120 man group that is the cost matrix plus a
  handful of swap passes, and deaths are bounded by the number of units, but it is work that was
  not being done before.
