### PR TITLE
Fix range check error when ordering a large group across a big map

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -33,6 +33,7 @@ KaM Remake Beta r_____ []
 + Fixed occasional an error caused by clicking a message in the message log after changing active hand
 + Fixed archers taking long detours in front of their group
 + Fixed crash on equipping a warrior after a recruit died inside the Barracks (#300)
++ Fixed crash on ordering a large group to walk far across a big map (#301)
 
 Campaigns:
 + Added French translations for 8 campaigns (and other minor corrections)

--- a/Utils/Testing_GameTests/KM_Test_Hungarian_LongWalk.pas
+++ b/Utils/Testing_GameTests/KM_Test_Hungarian_LongWalk.pas
@@ -1,0 +1,104 @@
+unit KM_Test_Hungarian_LongWalk;
+{$I KaM_Remake.inc}
+interface
+uses
+  KM_Test;
+
+type
+  TKMTest_HungarianLongWalk = class(TKMTest)
+  protected
+    procedure DoTick(aTick: Cardinal; var aKeepGoing: Boolean); override;
+    procedure SetUp; override;
+    procedure CheckResult; override;
+    procedure TearDown; override;
+  public
+    class function TestTags: TKMTestTagSet; override;
+    class function TestDescription: string; override;
+  end;
+
+
+implementation
+uses
+  SysUtils,
+  KM_Defaults, KM_Points, KM_CommonUtils,
+  KM_GameApp, KM_HandsCollection, KM_Terrain, KM_HandTypes,
+  KM_ResTypes, KM_UnitGroup, KM_UnitGroupTypes;
+
+
+{ TKMTest_HungarianLongWalk }
+procedure TKMTest_HungarianLongWalk.SetUp;
+begin
+  inherited;
+
+  DYNAMIC_TERRAIN := False;
+
+  // The largest map the game allows, which is where the rearrangement costs get biggest
+  gGameApp.NewGameEmptyMap(256, 256);
+
+  // Player controlled, so that no AI general orders the group about
+  gHands[0].HandType := hndHuman;
+
+  // With it off the group is never rearranged and the test has nothing to walk into
+  FEAT_HUNGARIAN_GROUP_ORDER := True;
+
+  // 300 men in 15 ranks, standing in the top left corner
+  gHands[0].AddUnitGroup(utBowman, KMPoint(20, 20), dirE, 20, 300);
+end;
+
+
+procedure TKMTest_HungarianLongWalk.TearDown;
+begin
+  inherited;
+  DYNAMIC_TERRAIN := True;
+end;
+
+
+procedure TKMTest_HungarianLongWalk.DoTick(aTick: Cardinal; var aKeepGoing: Boolean);
+var
+  canBeReached: Boolean;
+begin
+  // Let the group settle first, then send it to the opposite corner
+  if aTick <> 10 then Exit;
+
+  var group := gHands[0].UnitGroups[0];
+
+  // Add up the diagonal of the cost matrix the group is about to hand the solver. That is the
+  // accumulator which used to overflow, so the test has to know it gets past MaxInt
+  var costSum: Int64 := 0;
+  for var I := 1 to group.Count - 1 do
+  begin
+    var slot := GetPositionInGroup2(240, 240, dirS, I, group.UnitsPerRow, gTerrain.MapX, gTerrain.MapY, canBeReached);
+    costSum := costSum + Round(Sqr(10 * slot.GetLengthDiag(group.Members[I].Position)));
+  end;
+  AssertTrue(costSum > MaxInt, Format('Costs add up to %d, which still fits Integer', [costSum]));
+
+  group.OrderWalk(KMPoint(240, 240), True, wtokPlayerOrder, dirS);
+
+  aKeepGoing := False;
+end;
+
+
+procedure TKMTest_HungarianLongWalk.CheckResult;
+begin
+  var group := gHands[0].UnitGroups[0];
+
+  AssertTrue(group.Order = goWalkTo, 'Group should have taken the walk order');
+  AssertEquals(300, group.Count, 'Group should have kept all its men');
+end;
+
+
+class function TKMTest_HungarianLongWalk.TestTags: TKMTestTagSet;
+begin
+  Result := [tcBowman, tcCombat, tcPathfinding];
+end;
+
+
+class function TKMTest_HungarianLongWalk.TestDescription: string;
+begin
+  Result := 'Tests a large group''s ability to walk across a big map without overflowing the formation solver.';
+end;
+
+
+initialization
+  RegisterTest(TKMTest_HungarianLongWalk);
+end.

--- a/Utils/Testing_GameTests/Testing_GameTests.dpr
+++ b/Utils/Testing_GameTests/Testing_GameTests.dpr
@@ -25,6 +25,7 @@ uses
   KM_Test_FarmPlant in 'KM_Test_FarmPlant.pas',
   KM_Test_Fight95 in 'KM_Test_Fight95.pas',
   KM_Test_Hungarian in 'KM_Test_Hungarian.pas',
+  KM_Test_Hungarian_LongWalk in 'KM_Test_Hungarian_LongWalk.pas',
   KM_Test_Hungarian_SwapPerf in 'KM_Test_Hungarian_SwapPerf.pas',
   KM_Test_Mill in 'KM_Test_Mill.pas',
   KM_Test_Recruit_EatsAndReturns in 'KM_Test_Recruit_EatsAndReturns.pas',

--- a/Utils/Testing_GameTests/Testing_GameTests.dproj
+++ b/Utils/Testing_GameTests/Testing_GameTests.dproj
@@ -147,6 +147,7 @@
         <DCCReference Include="KM_Test_FarmPlant.pas"/>
         <DCCReference Include="KM_Test_Fight95.pas"/>
         <DCCReference Include="KM_Test_Hungarian.pas"/>
+        <DCCReference Include="KM_Test_Hungarian_LongWalk.pas"/>
         <DCCReference Include="KM_Test_Hungarian_SwapPerf.pas"/>
         <DCCReference Include="KM_Test_Mill.pas"/>
         <DCCReference Include="KM_Test_Recruit_EatsAndReturns.pas"/>

--- a/src/utils/algorithms/KM_Hungarian.pas
+++ b/src/utils/algorithms/KM_Hungarian.pas
@@ -90,8 +90,10 @@ end;
 procedure TSimpleSolver.Solve;
 var
   I, J: Integer;
-  Distance, Best, CostCurrent, CostSwap: Integer;
-  Swapped: Boolean;
+  Distance, Best: Integer;
+  // Sums over the whole group. One squared cost reaches ~13M on a full size map, so a few hundred
+  // men overflow Integer, and with range checks on that is a crash rather than a wrong number
+  CostCurrent, CostSwap: Int64;
 begin
   fHeight := Length(Costs);
   fWidth := Length(Costs[0]);
@@ -150,6 +152,9 @@ end;
 
 //Swap tasks between agents when it is more efficient to do so
 //Returns True if anything was swapped, so the caller can stop once the assignment settles
+//The costs here stay Integer on purpose - each one holds two cost cells at most, and this is the
+//hot loop (O(n^2) per pass), so widening it would cost more than it buys. Solve sums the whole
+//group and does need Int64
 function TSimpleSolver.DoSwaps: Boolean;
 var I, J, TaskToSwap, Best, CostCurrent, CostSwap: Integer;
 begin


### PR DESCRIPTION
Fixes #301.

`TSimpleSolver.Solve` finishes by adding up the cost matrix twice, to see whether the assignment it found beats a plain 1:1 one:

```pascal
CostCurrent := CostCurrent + Costs[I, Solution[I]];   // line 114 in the build the report came from
CostSwap := CostSwap + Costs[I, I];
```

Both accumulators were `Integer` while `Costs` is `Cardinal`. `HungarianReorderMembers` always asks for `huIndividual`, where a cost is `Round(Sqr(10 * GetLengthDiag))` - a squared distance, so a single pair already weighs millions and the sum over a few hundred men does not fit.

For the reporter's move from (15,15) to (240,240) one pair costs 10,064,756, so `MaxInt` is reached at 213 men. That matches the report: 200 men went through, 238 crashed. Worst case on a 256x256 map a pair costs ~12.93M, so it can go off from ~166 men.

Range checks are on in Release, so this is a hard crash rather than a wrong number.

The fix widens the two accumulators to `Int64`. `DoSwaps` keeps `Integer` on purpose and got a comment saying why - it only ever adds two cells, and it is the hot loop.

### Test

`TKMTest_HungarianLongWalk` sends a 300 man group corner to corner on a 256x256 map with a player walk order, which is the path from the stack trace. Before it orders the group it measures the diagonal of the matrix the solver is about to get - that is the `CostSwap` accumulator - and asserts it exceeds `MaxInt`, so the test cannot quietly stop covering the bug if the map size, the group size or the cost formula ever change.

| Build | Result |
|---|---|
| Before the fix | `EXCEPTION seed 4: Range check error` |
| After the fix | `SUCCESS` |

`TKMTest_Hungarian` and `TKMTest_HungarianSwapPerf` stay green. SwapPerf is the useful one here: it cross-checks the cost of its own matrix against `HungarianMatchPoints`, so it would notice if the change had shifted what the solver returns. It did not.