### PR TITLE
Fix range check error when a room slot has no start location (#316)

### DIFF
--- a/src/gui/pages_game/KM_GUIGameAllies.pas
+++ b/src/gui/pages_game/KM_GUIGameAllies.pas
@@ -145,7 +145,7 @@ end;
 
 procedure TKMGUIGameAllies.Allies_UpdateRoomMapping;
 var
-  I, J, K: Integer;
+  I, J, K, handIndex: Integer;
   teams: TKMByteSetArray;
   handIdToSlotIndex: array [0..MAX_HANDS - 1] of Integer;
 begin
@@ -160,7 +160,15 @@ begin
 
   for I := 1 to gNetworking.Room.Count do
     if not gNetworking.Room[I].IsSpectator then
-      handIdToSlotIndex[gNetworking.Room[I].HandIndex] := I;
+    begin
+      // A slot can be a non spectator and still have no hand: IsSpectator only tests for
+      // LOC_SPECTATE, while ResetLocAndReady puts every other start location back to LOC_RANDOM
+      // whenever the host picks a map or save, and HandIndex is then -1. A start location read off
+      // the wire is not validated either, so guard the upper end as well
+      handIndex := gNetworking.Room[I].HandIndex;
+      if (handIndex >= 0) and (handIndex < MAX_HANDS) then
+        handIdToSlotIndex[handIndex] := I;
+    end;
 
   teams := gHands.Teams;
 


### PR DESCRIPTION
Fixes #316. One file, ten lines.

## The defect

`TKMGamePlayInterface.UpdateRoomMapping` indexed its lookup table with an unchecked `HandIndex`:

```pascal
for I := 1 to gNetworking.Room.Count do
  if not gNetworking.Room[I].IsSpectator then
      handIdToRoomId[gNetworking.Room[I].HandIndex] := I;
```

`handIdToRoomId` is `array [0..MAX_HANDS - 1] of Integer`, and `TKMNetRoomSlot.GetHandIndex` returns `-1` whenever `StartLocation <= 0`. The `IsSpectator` filter does not exclude those, because it only tests for `LOC_SPECTATE`, which is `-1` — a slot sitting at `LOC_RANDOM`, which is `0`, passes straight through. The write then lands on `handIdToRoomId[-1]`.

The read side a few lines below already expected this to be possible:

```pascal
if handIdToRoomId[I] <> -1 then //handIdToRoomId could -1, if we play in the save, where 1 player left
```

so it was only the write that assumed otherwise.

## Where the bad state comes from

`ResetLocAndReady` puts every non spectator start location back to `LOC_RANDOM`, and is called from `SelectMap`, `SelectSave` and `SelectNoMap` — whenever the host picks a map or save in the lobby. Each of those is followed by a player list broadcast.

A client that is still in the game accepts that list: `mkPlayersList` is in `NET_ALLOWED_PACKETS_SET[lgsGame]` and in `[lgsReconnecting]`, while `mkResetMap` is in neither. So the client learns that the roster changed but not that the map did, updates its room from lobby shaped data, and walks into the unchecked write. `AlliesOnPingInfo` reaches the same code, so a ping broadcast is a second way in.

## The change

```pascal
handIndex := gNetworking.Room[I].HandIndex;
if InRange(handIndex, 0, MAX_HANDS - 1) then
  handIdToRoomId[handIndex] := I;
```

Slots with no hand are skipped, which is what the read side was already prepared for. The upper end is guarded as well rather than only testing for `-1`: `StartLocation` arrives over the network and `TKMNetRoom.LoadFromStream` does not validate it, so an out of range value is reachable the same way the `-1` is.

## Verification

The test that covers this is `MP_RosterZeroLoc` in #331, which adds multiplayer coverage to the test runner. It is deliberately not part of this PR, so that this one stays a pure fix. Measured with both applied together, on `9c65be92a`:

- without this commit: `MP_RosterZeroLoc` fails with `ERangeError: Range check error`
- with it: the test passes, and `--run-all` is 27 run, 1 failed — the remaining failure being `MP_RosterWithoutUs`, which covers #315

## Relationship to #296

They do not overlap, and both are needed. #296 guards `HandleMessagePlayersList` for the case where *our own* nickname has gone from the roster, leaving `fMySlotIndex` at `-1` and `MyRoomSlot` nil. I measured it on the #331 harness: it turns `MP_RosterWithoutUs` green and leaves `MP_RosterZeroLoc` red, because here our slot is still present and it is *another* slot that has no location. The two crashes share a stack but not a cause.

Worth noting for #296 specifically: its `Exit` also covers the second `MyRoomSlot` dereference further down `HandleMessagePlayersList`, in the `OnUpdateMinimap` branch — dead in game because `MultiplayerRig` nils that event, but live in the lobby. So that site needs no separate fix.

## Noticed nearby, deliberately left alone

`TKMNetRoomSlot.IsSpectator` is the only slot accessor without a `Self = nil` guard, and `TKMNetRoom.LoadFromStream` reads `fCount` off the wire with no bounds check while `fSlots` is `array[1..MAX_LOBBY_SLOTS]`. Together those would let a malformed packet put nil slots inside `Room.Count`. Out of scope here; happy to follow up separately if you want it hardened.
