### PR TITLE
Adapt UpdateRoomMapping fix from LifeFreedom after refactors

### DIFF
--- a/src/gui/pages_game/KM_GUIGameAllies.pas
+++ b/src/gui/pages_game/KM_GUIGameAllies.pas
@@ -2,6 +2,7 @@ unit KM_GUIGameAllies;
 {$I KaM_Remake.inc}
 interface
 uses
+  Math,
   KM_Controls, KM_ControlsBase, KM_ControlsDrop,
   KM_Defaults, KM_InterfaceGame;
 
@@ -152,7 +153,7 @@ end;
 
 procedure TKMGUIGameAllies.Allies_UpdateRoomMapping;
 var
-  I, J, K: Integer;
+  I, J, K, handIndex: Integer;
   teams: TKMByteSetArray;
   handIdToRoomId: array [0..MAX_HANDS - 1] of Integer;
 begin
@@ -167,7 +168,15 @@ begin
 
   for I := 1 to gNetworking.Room.Count do
     if not gNetworking.Room[I].IsSpectator then
-        handIdToRoomId[gNetworking.Room[I].HandIndex] := I;
+    begin
+      // A slot can be a non spectator and still have no hand: IsSpectator only tests for
+      // LOC_SPECTATE, while ResetLocAndReady puts every other start location back to LOC_RANDOM
+      // whenever the host picks a map or save, and HandIndex is then -1. A start location read off
+      // the wire is not validated either, so guard the upper end as well
+      handIndex := gNetworking.Room[I].HandIndex;
+      if InRange(handIndex, 0, MAX_HANDS - 1) then
+        handIdToRoomId[handIndex] := I;
+    end;
 
   teams := gHands.Teams;
 


### PR DESCRIPTION
Fix from PR https://github.com/reyandme/kam_remake/pull/332 from LifeFreedom, reapplied after Krom's refactors.

Fixes
> 7bb5f46b +000db KaM_Remake_fix315.exe KM_InterfaceGamePlay   1939  +12 TKMGamePlayInterface.UpdateRoomMapping
> 7bb64494 +00028 KaM_Remake_fix315.exe KM_InterfaceGamePlay   3341   +1 TKMGamePlayInterface.AlliesOnPingInfo

Happens while kicked player tries to reconnect to lobby with changed game state - detailed description here https://github.com/reyandme/kam_remake/issues/315#issuecomment-5460934645 